### PR TITLE
Check for validity of tid before accessing thrtab, existing code can lead to exception ( solved as part of cs503 homework at purdue university)

### DIFF
--- a/system/resume.c
+++ b/system/resume.c
@@ -21,12 +21,12 @@ syscall resume(tid_typ tid)
     int prio;
 
     im = disable();
-    thrptr = &thrtab[tid];
     if (isbadtid(tid) || (thrptr->state != THRSUSP))
     {
         restore(im);
         return SYSERR;
     }
+    thrptr = &thrtab[tid];
 
     prio = thrptr->prio;
     ready(tid, RESCHED_YES);


### PR DESCRIPTION
Should check for the validity of the tid before accessing the thread table ...
