### PR TITLE
Discard unknown sections otherwise they can get inserted before _start -...

### DIFF
--- a/compile/platforms/arm-rpi/ld.script
+++ b/compile/platforms/arm-rpi/ld.script
@@ -48,4 +48,8 @@ SECTIONS {
 
     . = ALIGN(64);
     _end = .;
+
+    /DISCARD/ : {
+        *(*)
+    }
 }


### PR DESCRIPTION
... ".note.gnu.build-id" being a particular problem here.

I was having problems with builds sometimes working, but often crashing immediately (either the rainbow screen or just blank). Turns out this gcc/ld version inserts a 36-byte section into the ELF file including a 16-byte header (which mostly disassembles as add/sub instructions) followed by a 20-byte hash. The linker then, not having any better instructions, inserts it first at the linker script's origin. Depending on exactly which instructions the hash represents (often invalid) this either has no visible effect or crashes before we can reach _start, or perturbs things enough that _start then fails.
