### PR TITLE
Allow some constants to be overridden in xinu.conf for very small systems

### DIFF
--- a/include/loopback.h
+++ b/include/loopback.h
@@ -11,7 +11,9 @@
 #include <stddef.h>
 #include <semaphore.h>
 
+#ifndef LOOP_BUFFER
 #define LOOP_BUFFER 1024        /**< loopback buffer length             */
+#endif
 
 /* LOOP device states */
 #define LOOP_STATE_FREE     0

--- a/include/thread.h
+++ b/include/thread.h
@@ -35,7 +35,9 @@
 #define BADTID      (-1)        /**< used when invalid tid needed       */
 
 /* thread initialization constants */
+#ifndef INITSTK
 #define INITSTK     65536       /**< initial thread stack size          */
+#endif
 #define INITPRIO    20          /**< initial thread priority            */
 #define MINSTK      128         /**< minimum thread stack size          */
 #ifdef JTAG_DEBUG

--- a/include/tty.h
+++ b/include/tty.h
@@ -11,7 +11,9 @@
 #include <stdarg.h>
 #include <stddef.h>
 
+#ifndef TTY_IBLEN
 #define TTY_IBLEN           1024 /**< input buffer length               */
+#endif
 
 /* TTY input flags */
 #define TTY_IRAW            0x01 /**< read unbuffered and uncooked      */

--- a/include/uart.h
+++ b/include/uart.h
@@ -11,8 +11,12 @@
 #include <stddef.h>
 
 /* UART Buffer lengths */
+#ifndef UART_IBLEN
 #define UART_IBLEN      1024
+#endif
+#ifndef UART_OBLEN
 #define UART_OBLEN      1024
+#endif
 
 #define UART_BAUD       115200  /**< Default console baud rate.         */
 


### PR DESCRIPTION
The default sizes for INITSTK, LOOP_BUFFER, UART_IBLEN, UART_OBLEN, and TTY_IBLEN are not appropriate for very small systems (RAM smaller than about 32 kB).  This patch allows such systems to define smaller values in xinu.conf.