### PR TITLE
Improve print_os_info on systems with non-contiguous memory maps

### DIFF
--- a/compile/platforms/arm-qemu/ld.script
+++ b/compile/platforms/arm-qemu/ld.script
@@ -32,6 +32,7 @@ SECTIONS {
     .text : {
         *(.text .text.*)
         *(.rodata .rodata.*)
+        _extext = .;
     }
 
     . = ALIGN(64);

--- a/compile/platforms/arm-rpi/ld.script
+++ b/compile/platforms/arm-rpi/ld.script
@@ -31,6 +31,7 @@ SECTIONS {
     .text : {
         *(.text .text.*)
         *(.rodata .rodata.*)
+        _etext = .;
     }
 
     . = ALIGN(64);

--- a/include/memory.h
+++ b/include/memory.h
@@ -45,8 +45,9 @@ extern struct memblock memlist;     /**< head of free memory list           */
 
 /* Other memory data */
 
-extern void *_end;              /**< linker provides end of image       */
-extern void *memheap;           /**< bottom of heap                     */
+extern void *_end;              /**< linker provides end of image           */
+extern void *_etext;            /**< linker provides end of text segment    */
+extern void *memheap;           /**< bottom of heap                         */
 
 /* Memory function prototypes */
 void *memget(uint);

--- a/system/main.c
+++ b/system/main.c
@@ -160,7 +160,7 @@ static void print_os_info(void)
             (ulong)platform.minaddr, (ulong)_start - 1);
 #endif
 
-    kprintf("%10d bytes Xinu code.\r\n", (ulong)&_end - (ulong)_start);
+    kprintf("%10d bytes Xinu code.\r\n", (ulong)&_etext - (ulong)_start);
 #ifdef DETAIL
     kprintf("           [0x%08X to 0x%08X]\r\n",
             (ulong)_start, (ulong)&_end - 1);


### PR DESCRIPTION
The print_os_info() function assumes contiguous memory maps (e.g., _etext == _sdata), which is often untrue on embedded systems.  This patch removes that assumption to some degree.