### PR TITLE
Allow platform configurations to define compiler flags for AS rules.

### DIFF
--- a/compile/Makefile
+++ b/compile/Makefile
@@ -310,7 +310,7 @@ objects: $(COMP_OBJ)
 
 %.o: %.S
 	@echo -e "\tAssembling" $@
-	$(CC) $(DEPFLAGS) $(ASFLAGS) -o $@ $<
+	$(CC) $(DEPFLAGS) $(ASFLAGS) $(ASCFLAGS) -o $@ $<
 
 clean:
 	@echo -e "\tCleaning all objects"


### PR DESCRIPTION
Platforms that set ASCFLAGS will have this variable passed to CC-as-AS
at compile time, which is necessary on Cortex-M processors with
arm-none-eabi-gcc to set thumb and processor-specific opcode generation.