### PR TITLE
Allow platformVars to provide the DATA variable for building Xinu.

### DIFF
--- a/compile/Makefile
+++ b/compile/Makefile
@@ -247,7 +247,7 @@ LIB_ARC  := $(LIBS:%=$(LIBDIR)/%.a)
 MAIN_OBJ := $(MAIN_SRC:%.c=%.o)
 
 # Data is relative to the compile directory
-DATA     := data
+DATA     ?= data
 
 DATA_SRC :=
 include $(DATA:%=%/Makerules)


### PR DESCRIPTION
This allows platforms that do not want to include any data to easily
configure this.