### PR TITLE
Updated ld.script for arm-qemu

### DIFF
--- a/compile/platforms/arm-qemu/ld.script
+++ b/compile/platforms/arm-qemu/ld.script
@@ -32,7 +32,7 @@ SECTIONS {
     .text : {
         *(.text .text.*)
         *(.rodata .rodata.*)
-        _extext = .;
+        _etext = .;
     }
 
     . = ALIGN(64);


### PR DESCRIPTION
Fixed typo that caused compilation to fail for arm-qemu: _extext must be _etext