### PR TITLE
Add support for 64 bit architectures

### DIFF
--- a/device/uart/kvprintf.c
+++ b/device/uart/kvprintf.c
@@ -33,7 +33,7 @@ syscall kvprintf(const char *format, va_list ap)
      * it prevents kprintf()'s from stepping on each other toes if you happen to
      * call kprintf() from an interrupt handler.  */
     im = disable();
-    retval = _doprnt(format, ap, (int (*)(int, int))kputc, (int)&devtab[SERIAL0]);
+    retval = _doprnt(format, ap, (int (*)(int, uintptr_t))kputc, (uintptr_t)&devtab[SERIAL0]);
     restore(im);
     return retval;
 }

--- a/include/endianness.h
+++ b/include/endianness.h
@@ -23,6 +23,20 @@ bswap32(uint32_t n)
     return (n << 24) | ((n & 0xff00) << 8) | ((n & 0xff0000) >> 8) | (n >> 24);
 }
 
+static inline uint64_t
+bswap64(uint64_t n)
+{
+    return((n & 0xff00000000000000) >> 56)	
+	| ((n & 0x00ff000000000000) >> 40)	
+	| ((n & 0x0000ff0000000000) >> 24)	
+	| ((n & 0x000000ff00000000) >> 8)	
+	| ((n & 0x00000000ff000000) << 8)	
+	| ((n & 0x0000000000ff0000) << 24)	
+	| ((n & 0x000000000000ff00) << 40)	
+	| ((n & 0x00000000000000ff) << 56);
+}
+
+
 #if BYTE_ORDER == BIG_ENDIAN
 
 /* Big-endian CPU  */
@@ -30,14 +44,18 @@ bswap32(uint32_t n)
 /* big endian to big endian:  no-op  */
 #  define cpu_to_be16(n)  n
 #  define cpu_to_be32(n)  n
+#  define cpu_to_be64(n)  n
 #  define be16_to_cpu(n)  n
 #  define be32_to_cpu(n)  n
+#  define be64_to_cpu(n)  n
 
 /* big endian to little endian and vice versa  */
 #  define cpu_to_le16(n)  bswap16(n)
 #  define cpu_to_le32(n)  bswap32(n)
+#  define cpu_to_le64(n)  bswap64(n)
 #  define le16_to_cpu(n)  bswap16(n)
 #  define le32_to_cpu(n)  bswap32(n)
+#  define le64_to_cpu(n)  bswap64(n)
 
 #else /* BYTE_ORDER == BIG_ENDIAN */
 
@@ -46,14 +64,18 @@ bswap32(uint32_t n)
 /* little endian to big endian and vice versa  */
 #  define cpu_to_be16(n)  bswap16(n)
 #  define cpu_to_be32(n)  bswap32(n)
+#  define cpu_to_be64(n)  bswap64(n)
 #  define be16_to_cpu(n)  bswap16(n)
 #  define be32_to_cpu(n)  bswap32(n)
+#  define be64_to_cpu(n)  bswap64(n)
 
 /* little endian to little endian:  no-op  */
 #  define cpu_to_le16(n)  n
 #  define cpu_to_le32(n)  n
+#  define cpu_to_le64(n)  n
 #  define le16_to_cpu(n)  n
 #  define le32_to_cpu(n)  n
+#  define le64_to_cpu(n)  n    
 
 #endif /* BYTE_ORDER != BIG_ENDIAN */
 

--- a/include/limits.h
+++ b/include/limits.h
@@ -28,7 +28,11 @@
 #define INT_MIN   (-INT_MAX-1)  /**< minimum value of int               */
 #define UINT_MAX  (2U*INT_MAX+1) /**< maximum value of unsigned int     */
 
+#ifdef __LP64__  /* 64 bit arch */
+#define LONG_MAX  9223372036854775807L  /**< maximum value of long      */
+#else            /* 32 bit arch */
 #define LONG_MAX  2147483647    /**< maximum value of long              */
+#endif
 #define LONG_MIN  (-LONG_MAX-1) /**< minimum value of long              */
 #define ULONG_MAX (2UL*LONG_MAX+1) /**< maximum value of unsigned long  */
 

--- a/include/memory.h
+++ b/include/memory.h
@@ -9,11 +9,13 @@
 #define _MEMORY_H_
 
 #include <stddef.h>
+#include <stdint.h>
 
+#define MEMORY_DMBDEC (2*sizeof(uintptr_t)-1)
 /* roundmb - round address up to size of memblock  */
-#define roundmb(x)  (void *)( (7 + (ulong)(x)) & ~0x07 )
+#define roundmb(x)  (void *)( (MEMORY_DMBDEC + (ulong)(x)) & ~MEMORY_DMBDEC )
 /* truncmb - truncate address down to size of memblock */
-#define truncmb(x)  (void *)( ((ulong)(x)) & ~0x07 )
+#define truncmb(x)  (void *)( ((ulong)(x)) & ~MEMORY_DMBDEC )
 
 /**
  * @ingroup memory_mgmt
@@ -38,7 +40,7 @@
 struct memblock
 {
     struct memblock *next;          /**< pointer to next memory block       */
-    uint length;                    /**< size of memory block (with struct) */
+    uintptr_t length;                    /**< size of memory block (with struct) */
 };
 
 extern struct memblock memlist;     /**< head of free memory list           */
@@ -50,8 +52,8 @@ extern void *_etext;            /**< linker provides end of text segment    */
 extern void *memheap;           /**< bottom of heap                         */
 
 /* Memory function prototypes */
-void *memget(uint);
-syscall memfree(void *, uint);
-void *stkget(uint);
+void *memget(uintptr_t);
+syscall memfree(void *, uintptr_t);
+void *stkget(uintptr_t);
 
 #endif                          /* _MEMORY_H_ */

--- a/include/stdint.h
+++ b/include/stdint.h
@@ -18,4 +18,12 @@ typedef unsigned short       uint16_t;
 typedef unsigned int         uint32_t;
 typedef unsigned long long   uint64_t;
 
+#if __LP64__
+typedef long int             intptr_t;
+typedef unsigned long int    uintptr_t;
+#else
+typedef int                  intptr_t;
+typedef unsigned int         uintptr_t;
+#endif
+
 #endif /* _STDINT_H_ */

--- a/include/stdio.h
+++ b/include/stdio.h
@@ -6,6 +6,7 @@
 #ifndef _STDIO_H_
 #define _STDIO_H_
 
+#include <stdint.h>
 #include <compiler.h>
 #include <stdarg.h>
 #include <thread.h>  /* For thrtab and thrcurrent. */
@@ -31,8 +32,8 @@
 
 /* Formatted input  */
 int _doscan(const char *fmt, va_list ap,
-            int (*getch) (int, int), int (*ungetch) (int, int),
-            int arg1, int arg2);
+            int (*getch) (int, uintptr_t), int (*ungetch) (int, uintptr_t),
+            int arg1, uintptr_t arg2);
 
 int fscanf(int dev, const char *format, ...);
 
@@ -45,7 +46,7 @@ int sscanf(const char *str, const char *format, ...);
 
 /* Formatted output  */
 int _doprnt(const char *format, va_list,
-	    int (*putc_func)(int, int), int putc_arg);
+	    int (*putc_func)(int, uintptr_t), uintptr_t putc_arg);
 
 int fprintf(int dev, const char *format, ...) __printf_format(2, 3);
 int printf(const char *format, ...) __printf_format(1, 2);

--- a/lib/libxc/doprnt.c
+++ b/lib/libxc/doprnt.c
@@ -84,7 +84,7 @@ enum integer_size {
  *      number of characters written on success, or @c EOF on failure
  */
 int _doprnt(const char *fmt, va_list ap,
-            int (*putc_func) (int, int), int putc_arg)
+            int (*putc_func) (int, uintptr_t), uintptr_t putc_arg)
 {
     int chars_written = 0;      /* Number of characters written so far  */
 

--- a/lib/libxc/doscan.c
+++ b/lib/libxc/doscan.c
@@ -20,15 +20,15 @@ enum integer_size {
 
 static int scan_string(char *ptr, int type, uint maxlen,
                        const uchar *stopchar_tab,
-                       int (*getch) (int, int), int (*ungetch) (int, int),
-                       int arg1, int arg2, bool *eofptr);
+                       int (*getch) (int, uintptr_t), int (*ungetch) (int, uintptr_t),
+                       int arg1, uintptr_t arg2, bool *eofptr);
 
 static int scan_number_or_string(void *ptr, uchar type, uint maxlen,
                                  enum integer_size size,
                                  const uchar *stopchar_tab,
-                                 int (*getch) (int, int),
-                                 int (*ungetch) (int, int),
-                                 int arg1, int arg2, bool *eofptr);
+                                 int (*getch) (int, uintptr_t),
+                                 int (*ungetch) (int, uintptr_t),
+                                 int arg1, uintptr_t arg2, bool *eofptr);
 
 static const uchar *build_stopchar_tab(const uchar *ufmt, uchar *stopchar_tab);
 
@@ -81,8 +81,8 @@ static const uchar *build_stopchar_tab(const uchar *ufmt, uchar *stopchar_tab);
  *      returned.
  */
 int _doscan(const char *fmt, va_list ap,
-            int (*getch) (int, int), int (*ungetch) (int, int),
-            int arg1, int arg2)
+            int (*getch) (int, uintptr_t), int (*ungetch) (int, uintptr_t),
+            int arg1, uintptr_t arg2)
 {
     int nmatch;
     uint maxlen;
@@ -235,8 +235,8 @@ int _doscan(const char *fmt, va_list ap,
 }
 
 static int scan_string(char *ptr, int type, uint maxlen, const uchar *stopchar_tab,
-                       int (*getch) (int, int), int (*ungetch) (int, int),
-                       int arg1, int arg2, bool *eofptr)
+                       int (*getch) (int, uintptr_t), int (*ungetch) (int, uintptr_t),
+                       int arg1, uintptr_t arg2, bool *eofptr)
 {
     uint len;
     int c;
@@ -290,9 +290,9 @@ static int scan_string(char *ptr, int type, uint maxlen, const uchar *stopchar_t
 static int scan_number_or_string(void *ptr, uchar type, uint maxlen,
                                  enum integer_size size,
                                  const uchar *stopchar_tab,
-                                 int (*getch) (int, int),
-                                 int (*ungetch) (int, int),
-                                 int arg1, int arg2, bool *eofptr)
+                                 int (*getch) (int, uintptr_t),
+                                 int (*ungetch) (int,uintptr_t),
+                                 int arg1, uintptr_t arg2, bool *eofptr)
 {
     int c = EOF;
     ulong n;

--- a/lib/libxc/fprintf.c
+++ b/lib/libxc/fprintf.c
@@ -30,7 +30,7 @@ int fprintf(int dev, const char *format, ...)
     int ret;
 
     va_start(ap, format);
-    ret = _doprnt(format, ap, fputc, dev);
+    ret = _doprnt(format, ap,  (int (*)(int,  uintptr_t)) fputc, (uintptr_t) dev);
     va_end(ap);
     return ret;
 }

--- a/lib/libxc/fscanf.c
+++ b/lib/libxc/fscanf.c
@@ -6,8 +6,8 @@
 #include <stdarg.h>
 #include <stdio.h>
 
-static int getch(int, int);
-static int ungetch(int, int);
+static int getch(int, uintptr_t);
+static int ungetch(int, uintptr_t);
 
 struct ch_buf
 {
@@ -44,14 +44,14 @@ int fscanf(int dev, const char *format, ...)
 
     buf.ch_avail = FALSE;
     va_start(ap, format);
-    ret = _doscan(format, ap, getch, ungetch, dev, (int)&buf);
+    ret = _doscan(format, ap, getch, ungetch, dev, (uintptr_t)&buf);
     va_end(ap);
     return ret;
 }
 
 /* Get a character from the device, storing it in the character buffer in case
  * an unget is requested.  */
-static int getch(int dev, int _ch_buf)
+static int getch(int dev, uintptr_t _ch_buf)
 {
     struct ch_buf *buf = (struct ch_buf *)_ch_buf;
     int c;
@@ -72,7 +72,7 @@ static int getch(int dev, int _ch_buf)
 }
 
 /* Put back a character.  */
-static int ungetch(int dev, int _chbuf)
+static int ungetch(int dev, uintptr_t _chbuf)
 {
     struct ch_buf *buf = (struct ch_buf *)_chbuf;
 

--- a/lib/libxc/malloc.c
+++ b/lib/libxc/malloc.c
@@ -35,7 +35,7 @@ void *malloc(size_t size)
 
     /* acquire memory from kernel */
     pmem = (struct memblock *)memget(size);
-    if (SYSERR == (uint)pmem)
+    if (SYSERR == (intptr_t)pmem)
     {
         return NULL;
     }

--- a/lib/libxc/printf.c
+++ b/lib/libxc/printf.c
@@ -28,7 +28,7 @@ int printf(const char *format, ...)
     int ret;
 
     va_start(ap, format);
-    ret = _doprnt(format, ap, fputc, stdout);
+    ret = _doprnt(format, ap,  (int (*)(int,  uintptr_t))  fputc, (uintptr_t)stdout);
     va_end(ap);
 
     return ret;

--- a/lib/libxc/sprintf.c
+++ b/lib/libxc/sprintf.c
@@ -6,7 +6,7 @@
 #include <stdarg.h>
 #include <stdio.h>
 
-static int sprntf(int, int);
+static int sprntf(int, uintptr_t);
 
 /**
  * @ingroup libxc
@@ -33,7 +33,7 @@ int sprintf(char *str, const char *format, ...)
 
     s = str;
     va_start(ap, format);
-    _doprnt(format, ap, sprntf, (int)&s);
+    _doprnt(format, ap, sprntf, (uintptr_t) &s);
     va_end(ap);
     *s = '\0';
 
@@ -43,7 +43,7 @@ int sprintf(char *str, const char *format, ...)
 /*
  * Routine called by _doprnt() to output each character.
  */
-static int sprntf(int c, int _sptr)
+static int sprntf(int c, uintptr_t _sptr)
 {
     char **sptr = (char **)_sptr;
     char *s = *sptr;

--- a/lib/libxc/sscanf.c
+++ b/lib/libxc/sscanf.c
@@ -8,8 +8,8 @@
 #include <stddef.h>
 #include <stdio.h>
 
-static int sgetch(int, int);
-static int sungetch(int, int);
+static int sgetch(int, uintptr_t);
+static int sungetch(int, uintptr_t);
 
 /**
  * @ingroup libxc
@@ -36,7 +36,7 @@ int sscanf(const char *str, const char *format, ...)
     int ret;
 
     va_start(ap, format);
-    ret = _doscan(format, ap, sgetch, sungetch, 0, (int)&str);
+    ret = _doscan(format, ap, sgetch, sungetch, 0, (uintptr_t) &str);
     va_end(ap);
 
     return ret;
@@ -45,7 +45,7 @@ int sscanf(const char *str, const char *format, ...)
 /* The first argument to the below functions is ignored, as we only need one
  * argument to specify the current position in the string.  */
 
-static int sgetch(int _ignored, int _str_p)
+static int sgetch(int _ignored, uintptr_t _str_p)
 {
     const char **str_p = (const char **)_str_p;
     const char *str = *str_p;
@@ -63,7 +63,7 @@ static int sgetch(int _ignored, int _str_p)
     return c;
 }
 
-static int sungetch(int _ignored, int _str_p)
+static int sungetch(int _ignored, uintptr_t _str_p)
 {
     const char **str_p = (const char**)_str_p;
     const char *str = *str_p;

--- a/mailbox/mailboxAlloc.c
+++ b/mailbox/mailboxAlloc.c
@@ -42,7 +42,7 @@ syscall mailboxAlloc(uint count)
             mbxptr->msgs = memget(sizeof(int) * count);
 
             /* check if memory was allocated correctly */
-            if (SYSERR == (int)mbxptr->msgs)
+            if (SYSERR == (intptr_t)mbxptr->msgs)
             {
                 break;
             }

--- a/system/create.c
+++ b/system/create.c
@@ -48,7 +48,7 @@ tid_typ create(void *procaddr, uint ssize, int priority,
 
     /* Allocate new stack.  */
     saddr = stkget(ssize);
-    if (SYSERR == (int)saddr)
+    if (SYSERR == (intptr_t)saddr)
     {
         restore(im);
         return SYSERR;

--- a/system/initialize.c
+++ b/system/initialize.c
@@ -106,9 +106,9 @@ static int sysinit(void)
     memheap = roundmb(memheap);
     platform.maxaddr = truncmb(platform.maxaddr);
     memlist.next = pmblock = (struct memblock *)memheap;
-    memlist.length = (uint)(platform.maxaddr - memheap);
+    memlist.length = (uintptr_t)(platform.maxaddr - memheap);
     pmblock->next = NULL;
-    pmblock->length = (uint)(platform.maxaddr - memheap);
+    pmblock->length = (uintptr_t)(platform.maxaddr - memheap);
 
     /* Initialize thread table */
     for (i = 0; i < NTHREAD; i++)

--- a/system/main.c
+++ b/system/main.c
@@ -129,6 +129,19 @@ thread main(void)
     return 0;
 }
 
+
+#ifdef DETAIL
+extern ulong cpuid;
+#endif
+
+#if __LP64__
+#define HEXWIDTH 16
+#define DECWIDTH 20
+#else
+#define HEXWIDTH 8
+#define DECWIDTH 10
+#endif
+
 /* Start of kernel in memory (provided by linker)  */
 extern void _start(void);
 
@@ -139,44 +152,49 @@ static void print_os_info(void)
 
 #ifdef DETAIL
     /* Output detected platform. */
-    kprintf("Processor identification: 0x%08X\r\n", cpuid);
+    kprintf("Processor identification: 0x%lX\r\n", cpuid);
     kprintf("Detected platform as: %s, %s\r\n\r\n",
             platform.family, platform.name);
 #endif
 
     /* Output Xinu memory layout */
-    kprintf("%10d bytes physical memory.\r\n",
-            (ulong)platform.maxaddr - (ulong)platform.minaddr);
+    kprintf("%*ld bytes physical memory.\r\n",
+	    DECWIDTH, (uintptr_t)platform.maxaddr - (uintptr_t)platform.minaddr);
 #ifdef DETAIL
-    kprintf("           [0x%08X to 0x%08X]\r\n",
-            (ulong)platform.minaddr, (ulong)(platform.maxaddr - 1));
+    kprintf("           [0x%0*X to 0x%0*X]\r\n",
+	    HEXWIDTH, (uintptr_t)platform.minaddr,
+	    HEXWIDTH, (uintptr_t)(platform.maxaddr - 1));
 #endif
 
-
-    kprintf("%10d bytes reserved system area.\r\n",
-            (ulong)_start - (ulong)platform.minaddr);
+    kprintf("%*ld bytes reserved system area.\r\n",
+	    DECWIDTH, (uintptr_t)_start - (uintptr_t)platform.minaddr);
 #ifdef DETAIL
-    kprintf("           [0x%08X to 0x%08X]\r\n",
-            (ulong)platform.minaddr, (ulong)_start - 1);
+    kprintf("           [0x%0*lX to 0x%0*lX]\r\n", 
+	    HEXWIDTH, (uintptr_t)platform.minaddr,
+	    HEXWIDTH, (uintptr_t)_start - 1);
 #endif
 
-    kprintf("%10d bytes Xinu code.\r\n", (ulong)&_etext - (ulong)_start);
+    kprintf("%*ld bytes Xinu code.\r\n", DECWIDTH, (uintptr_t)&_etext - (uintptr_t)_start);
 #ifdef DETAIL
-    kprintf("           [0x%08X to 0x%08X]\r\n",
-            (ulong)_start, (ulong)&_end - 1);
+    kprintf("           [0x%0*lX to 0x%0*lX]\r\n",
+	    HEXWIDTH, (uintptr_t)_start,
+	    HEXWIDTH, (uintptr_t)&_end - 1);
 #endif
 
-    kprintf("%10d bytes stack space.\r\n", (ulong)memheap - (ulong)&_end);
+    kprintf("%*ld bytes stack space.\r\n",
+	    DECWIDTH, (uintptr_t)memheap - (uintptr_t)&_end);
 #ifdef DETAIL
-    kprintf("           [0x%08X to 0x%08X]\r\n",
-            (ulong)&_end, (ulong)memheap - 1);
+    kprintf("           [0x%0*lX to 0x%0*lX]\r\n",
+	    HEXWIDTH, (uintptr_t)&_end,
+	    HEXWIDTH, (uintptr_t)memheap - 1);
 #endif
 
-    kprintf("%10d bytes heap space.\r\n",
-            (ulong)platform.maxaddr - (ulong)memheap);
+    kprintf("%*ld bytes heap space.\r\n",
+            DECWIDTH, (uintptr_t)platform.maxaddr - (uintptr_t)memheap);
 #ifdef DETAIL
-    kprintf("           [0x%08X to 0x%08X]\r\n\r\n",
-            (ulong)memheap, (ulong)platform.maxaddr - 1);
+    kprintf("           [0x%0*lX to 0x%0*lX]\r\n\r\n",
+	    HEXWIDTH, (uintptr_t)memheap,
+	    HEXWIDTH, (uintptr_t)platform.maxaddr - 1);
 #endif
     kprintf("\r\n");
 }

--- a/system/memfree.c
+++ b/system/memfree.c
@@ -23,7 +23,7 @@
  *      ::OK on success; ::SYSERR on failure.  This function can only fail
  *      because of memory corruption or specifying an invalid memory block.
  */
-syscall memfree(void *memptr, uint nbytes)
+syscall memfree(void *memptr, uintptr_t nbytes)
 {
     register struct memblock *block, *next, *prev;
     irqmask im;

--- a/system/memget.c
+++ b/system/memget.c
@@ -21,7 +21,7 @@
  *      The returned pointer is guaranteed to be 8-byte aligned.  Free the block
  *      with memfree() when done with it.
  */
-void *memget(uint nbytes)
+void *memget(uintptr_t nbytes)
 {
     register struct memblock *prev, *curr, *leftover;
     irqmask im;

--- a/system/stkget.c
+++ b/system/stkget.c
@@ -24,7 +24,7 @@
  *      the base of a stack growing down.  Free the stack with stkfree() when
  *      done with it.
  */
-void *stkget(uint nbytes)
+void *stkget(uintptr_t nbytes)
 {
     irqmask im;
     struct memblock *prev, *next, *fits, *fitsprev;
@@ -35,7 +35,7 @@ void *stkget(uint nbytes)
     }
 
     /* round to multiple of memblock size   */
-    nbytes = (uint)roundmb(nbytes);
+    nbytes = (uintptr_t)roundmb(nbytes);
 
     im = disable();
 
@@ -76,5 +76,5 @@ void *stkget(uint nbytes)
 
     memlist.length -= nbytes;
     restore(im);
-    return (void *)((ulong)fits + nbytes - sizeof(int));
+    return (void *)((ulong)fits + nbytes - sizeof(void*));
 }

--- a/test/test_libStdio.c
+++ b/test/test_libStdio.c
@@ -235,7 +235,7 @@ static const struct {
     const char *format;
     const char *expected_output;
     uint nargs;
-    uint args[4]; /* Assumes all args are 4 bytes. */
+    uintptr_t args[4]; /* Assumes all args are 4 bytes. */
 } fprintf_specs[] = {
     { /* Empty string */
         .format = "",
@@ -247,7 +247,7 @@ static const struct {
         .format = "%s",
         .expected_output = "",
         .nargs = 1,
-        .args = {(uint)""},
+        .args = {(uintptr_t)""},
     },
     { /* Binary number */
         .format = "%b",
@@ -295,7 +295,7 @@ static const struct {
         .format = "%s",
         .expected_output = "aoeu",
         .nargs = 1,
-        .args = {(uint)"aoeu"},
+        .args = {(uintptr_t)"aoeu"},
     },
     { /* Null string */
         .format = "%s",
@@ -325,55 +325,55 @@ static const struct {
         .format = "%.5s",
         .expected_output = "trunc",
         .nargs = 1,
-        .args = {(uint)"truncate me"},
+        .args = {(uintptr_t)"truncate me"},
     },
     { /* Truncated string, max-width specified as vararg */
         .format = "%.*s",
         .expected_output = "trunc",
         .nargs = 2,
-        .args = {5, (uint)"truncate me"},
+        .args = {5, (uintptr_t)"truncate me"},
     },
     { /* Non-truncated string, negative max-width has no effect  */
         .format = "%.*s",
         .expected_output = "truncate me",
         .nargs = 2,
-        .args = {-1, (uint)"truncate me"},
+        .args = {-1, (uintptr_t)"truncate me"},
     },
     { /* Truncated string, implicit zero max-width   */
         .format = "%.s",
         .expected_output = "",
         .nargs = 1,
-        .args = {(uint)"truncate me"},
+        .args = {(uintptr_t)"truncate me"},
     },
     { /* Right justified string */
         .format = "%10s",
         .expected_output = "     right",
         .nargs = 1,
-        .args = {(uint)"right"},
+        .args = {(uintptr_t)"right"},
     },
     { /* Right justified string, min-width specified as vararg */
         .format = "%*s",
         .expected_output = "     right",
         .nargs = 2,
-        .args = {10, (uint)"right"},
+        .args = {10, (uintptr_t)"right"},
     },
     { /* Left justified string */
         .format = "%-8s",
         .expected_output = "left    ",
         .nargs = 1,
-        .args = {(uint)"left"},
+        .args = {(uintptr_t)"left"},
     },
     { /* Left justified string, min-width specified as vararg */
         .format = "%-*s",
         .expected_output = "left    ",
         .nargs = 2,
-        .args = {8, (uint)"left"},
+        .args = {8, (uintptr_t)"left"},
     },
     { /* Left justified string via negative min-width specified as vararg */
         .format = "%*s",
         .expected_output = "left    ",
         .nargs = 2,
-        .args = {-8, (uint)"left"},
+        .args = {-8, (uintptr_t)"left"},
     },
     { /* Negative integer */
         .format = "%d",
@@ -397,7 +397,7 @@ static const struct {
         .format = "%u",
         .expected_output = "2147483648",
         .nargs = 1,
-        .args = {(uint)INT_MAX + 1},
+        .args = {(uintptr_t)INT_MAX + 1},
     },
     { /* min width (left justified, overriding zero padding) */
         .format = "%-06d", /* '-' overrides '0' */
@@ -433,13 +433,13 @@ static const struct {
         .format = "%23s",
         .expected_output = "     ""     ""     ""     ""123",
         .nargs = 1,
-        .args = {(uint)"123"},
+        .args = {(uintptr_t)"123"},
     },
     { /* Large max width */
         .format = "%.23s",
         .expected_output = "abcdefghijklmnopqrstuvw",
         .nargs = 1,
-        .args = {(uint)"abcdefghijklmnopqrstuvwxyz"},
+        .args = {(uintptr_t)"abcdefghijklmnopqrstuvwxyz"},
     },
     { /* Zero */
         .format = "%d",
@@ -517,7 +517,7 @@ static const struct {
         .format = "literal %08d\t%-8s\t%c%cliteral",
         .expected_output = "literal 00004000\tfoobar  \t\xfeXliteral",
         .nargs = 4,
-        .args = {4000, (uint)"foobar", 0xfe, 'X'},
+        .args = {4000, (uintptr_t)"foobar", 0xfe, 'X'},
     },
 };
 
@@ -532,7 +532,7 @@ static bool do_detailed_fprintf_tests(bool verbose, bool passed)
         const char *format = fprintf_specs[i].format;
         const char *expected_output = fprintf_specs[i].expected_output;
         uint nargs = fprintf_specs[i].nargs;
-        const uint *args = fprintf_specs[i].args;
+        const uintptr_t *args = fprintf_specs[i].args;
         int ret;
         int len = strlen(expected_output);
         uchar obuf[len + 1];

--- a/test/test_memory.c
+++ b/test/test_memory.c
@@ -20,7 +20,7 @@ thread test_memory(bool verbose)
     /* Allocate a small piece of memory */
     testPrint(verbose, "Allocate small piece");
     testblock = (struct memblock *)memget(1);
-    if (SYSERR == (uint)testblock)
+    if (SYSERR == (intptr_t)testblock)
     {
         passed = FALSE;
         testFail(verbose, "memget SYSERR");
@@ -68,7 +68,7 @@ thread test_memory(bool verbose)
     }
 
     saddr = stkget(1);
-    if (SYSERR == (uint)saddr)
+    if (SYSERR == (intptr_t)saddr)
     {
         passed = FALSE;
         testFail(verbose, "\nstkget SYSERR");


### PR DESCRIPTION
This PR adds support for 64 bit architectures in preparation for the RISC-V 64 port.

It contains the following changes:

Fix the code that assumes that pointers and int have the same
size: use uintptr_t or intptr_t instead.

Introduce macros for byte swapping of 64 bit values

Conditionally define some relevant macros.

Allow printing of 64 bit addresses at system start and in
memory status.