### PR TITLE
RISCV64 qemu virt board port

### DIFF
--- a/compile/arch/riscv64/platformVars
+++ b/compile/arch/riscv64/platformVars
@@ -1,0 +1,24 @@
+#
+# Makefile definitions for Embedded Xinu shared between all supported RISCV64
+# platforms.
+#
+
+TEMPLATE_ARCH := riscv64
+
+# Architecture root and prefix (ignored if user overrides COMPILER_ROOT from the
+# toplevel Makefile).
+ARCH_ROOT     :=
+ARCH_PREFIX   := riscv64-unknown-elf-
+
+# Flag for producing GDB debug information.
+BUGFLAG       := -gstabs+
+
+# Objcopy flags, used for including data files in the resulting binary.
+OCFLAGS       := -I binary -O elf64-littleriscv -B riscv
+
+# Add a way to test for any RISCV64 platform in C code.
+DEFS          += -D_XINU_ARCH_RISCV64_
+
+# Default built target.  For RISCV64 we just translate the kernel into a raw binary.
+$(BOOTIMAGE): xinu.elf
+	$(OBJCOPY) -O binary $^ $@

--- a/compile/platforms/riscv64-qemu/ld.script
+++ b/compile/platforms/riscv64-qemu/ld.script
@@ -1,0 +1,54 @@
+/**
+ * @file ld.script
+ *
+ * This is the linker script for the Xinu kernel on the RISCV64 qemu virt 
+ * platform (emulated virt board features CLINT, PLIC, 16550A UART, VirtIO, 
+ * device-tree, Priv ISA v1.10). 
+
+ * QEMU loads the kernel from the xinu.elf file and starts execution in the
+ * emulated ROM on address 0x1000, from there it will jump to the provided
+ * _start entry point address (that we place at 0x80000000).
+ * 
+ * Every section is aligned on a 64-byte (cache block) boundary.
+ */
+/* Embedded Xinu, Copyright (C) 2018.  All rights reserved. */
+
+ENTRY(_start)
+
+SECTIONS {
+      . = 0x80000000;
+    .init : {
+        *(.init .init.*)
+    }
+
+    . = ALIGN(64);
+
+    .text : {
+        *(.text .text.*)
+        *(.rodata .rodata.*)
+        _etext = .;
+    }
+
+    . = ALIGN(64);
+
+    .data : {
+        *(.data .data.*)
+    }
+
+    . = ALIGN(64);
+
+    _bss = . ;
+    .bss : {
+        *(.bss .bss.*)
+    }
+
+    . = ALIGN(64);
+    _end = .;
+
+    /* Discard comment and note (but not debugging) sections.  Some
+     * versions of GNU ld would otherwise automatically place the
+     * ".note.gnu.build-id" section before _start!  */
+    /DISCARD/ : {
+        *(.comment .comment.* .note .note.*)
+    }
+}

--- a/compile/platforms/riscv64-qemu/platformVars
+++ b/compile/platforms/riscv64-qemu/platformVars
@@ -1,0 +1,35 @@
+#
+# Platform-specific Makefile definitions for the RISCV64 SPIKE port
+#
+
+# Include default RISCV64 definitions
+include arch/riscv64/platformVars
+
+PLATFORM_NAME := RISCV64 QEMU
+
+# Set extra compiler and assembler flags
+#
+CFLAGS   += -fPIE -O0
+
+# Add a define so we can test for RISCV64 QEMU in C code if absolutely needed
+DEFS     += -D_XINU_PLATFORM_RISCV64_QEMU_
+
+# Embedded Xinu components to build into the kernel image
+APPCOMPS := shell apps mailbox test
+# TODO: network
+
+# the --no-warn-mismatch option is required for successfull linking of
+# data files: Object files are compiled with the elf e_flags header
+# field according to the ABI setting (0x5 = hard float-double |
+# compressed instructions). Objcopy, on the other hand, does not seem
+# to be able to set compatible flag and without this option final
+# linking would fail.
+LDFLAGS+=--no-warn-mismatch
+
+# Embedded Xinu device drivers to build into the kernel image
+DEVICES  := tty  loopback uart-ns16550
+# TODO: ethloop  udp tcp telnet
+#        raw             \
+#        tcp             \
+#        telnet          \
+#        udp     

--- a/compile/platforms/riscv64-qemu/xinu.conf
+++ b/compile/platforms/riscv64-qemu/xinu.conf
@@ -1,0 +1,140 @@
+/* Configuration - (device configuration specifications)  */
+/* Unspecified switches default to ioerr                  */
+/*  -i    init          -o    open      -c    close       */
+/*  -r    read          -g    getc      -p    putc        */
+/*  -w    write         -s    seek      -n    control     */
+/*  -intr interrupt     -csr  csr       -irq  irq         */
+
+/* "type" declarations for both real- and pseudo- devices */
+
+/* simple loopback device */
+loopback:
+	on LOOPBACK -i loopbackInit -o loopbackOpen  -c loopbackClose
+	            -r loopbackRead -g loopbackGetc  -p loopbackPutc
+	            -w loopbackWrite -n loopbackControl
+
+/* null device */
+null:
+    on NOTHING  -i ionull       -o ionull        -c ionull
+                -r ionull       -g ionull        -p ionull
+                -w ionull
+
+/* physical uart device */
+uart:
+	on HARDWARE -i uartInit     -o ionull        -c ionull
+	            -r uartRead     -g uartGetc      -p uartPutc
+	            -w uartWrite    -n uartControl
+                -intr uartInterruptNoRsch
+
+/* tty pseudo-devices */
+tty:
+	on SOFTWARE -i ttyInit      -o ttyOpen       -c ttyClose
+	            -r ttyRead      -g ttyGetc       -p ttyPutc
+	            -w ttyWrite     -n ttyControl
+
+
+/* simple Ethernet loopback device */
+/*ethloop:
+	on ETHLOOP  -i ethloopInit  -o ethloopOpen   -c ethloopClose
+	            -r ethloopRead  -w ethloopWrite  -n ethloopControl
+*/
+/* udp devices */
+/*
+udp:
+    on NET      -i udpInit      -o udpOpen       -c udpClose
+                -r udpRead      -w udpWrite      -n udpControl
+*/
+
+/* raw sockets */
+/*raw:
+	on SOFTWARE -i rawInit      -o rawOpen       -c rawClose
+                -r rawRead      -w rawWrite      -n rawControl*/
+
+/* tcp devices */
+/*
+tcp:
+    on SOFTWARE -i tcpInit      -o tcpOpen       -c tcpClose
+                -r tcpRead      -g tcpGetc       -w tcpWrite
+                -p tcpPutc      -n tcpControl
+*/
+/* telnet devices */
+/*
+telnet:
+    on TCP      -i telnetInit   -o telnetOpen   -c telnetClose
+                -r telnetRead   -g telnetGetc   -w telnetWrite
+                -p telnetPutc   -n telnetControl
+*/
+%%
+SERIAL0   is uart     on HARDWARE csr 0x10000000 irq 10 
+
+DEVNULL   is null     on NOTHING
+
+/* Loopback device  */
+LOOP0     is loopback on LOOPBACK
+
+/* TTY for SERIAL0  */
+CONSOLE   is tty      on SOFTWARE
+
+/* TTY for LOOP0 (needed in testsuite)  */
+TTYLOOP   is tty      on SOFTWARE
+
+/* Physical ethernet raw packet interface */
+/*ETH0      is ether    on HARDWARE*/
+
+/* A Ethernet Loopback device */
+/*ELOOP     is ethloop  on ETHLOOP*/
+
+/* Raw sockets */
+/*RAW0      is raw      on SOFTWARE
+RAW1      is raw      on SOFTWARE*/
+
+/* UDP devices */
+
+/*UDP0      is udp      on NET
+UDP1      is udp      on NET
+UDP2      is udp      on NET
+UDP3      is udp      on NET*/
+
+/* TCP devices */
+
+/*TCP0      is tcp      on SOFTWARE
+TCP1      is tcp      on SOFTWARE
+TCP2      is tcp      on SOFTWARE
+TCP3      is tcp      on SOFTWARE
+TCP4      is tcp      on SOFTWARE
+TCP5      is tcp      on SOFTWARE
+TCP6      is tcp      on SOFTWARE*/
+
+/* TELNET */
+/*TELNET0 is telnet on TCP
+TELNET1 is telnet on TCP
+TELNET2 is telnet on TCP*/
+
+
+
+%%
+
+#define IRQ_TIMER     0
+
+/* Configuration and Size Constants */
+
+#define LITTLE_ENDIAN 0x1234
+#define BIG_ENDIAN    0x4321
+
+#define BYTE_ORDER    LITTLE_ENDIAN
+
+#define NTHREAD   100           /* number of user threads           */
+#define NSEM      100           /* number of semaphores             */
+#define NMAILBOX  15            /* number of mailboxes              */
+#define RTCLOCK   TRUE          /* timer support                    */
+#define NETEMU    FALSE         /* Network Emulator support         */
+#define NVRAM     FALSE         /* nvram support                    */
+#define SB_BUS    FALSE         /* Silicon Backplane support        */
+#define USE_TLB   FALSE         /* make use of TLB                  */
+#define USE_TAR   FALSE         /* enable data archives             */
+#define NPOOL     8             /* number of buffer pools available */
+#define POOL_MAX_BUFSIZE 2048   /* max size of a buffer in a pool   */
+#define POOL_MIN_BUFSIZE 8      /* min size of a buffer in a pool   */
+#define POOL_MAX_NBUFS   8192   /* max number of buffers in a pool  */
+#define NUART     1
+#define UART_FIFO_LEN   16

--- a/device/uart-ns16550/uartInterrupt.c
+++ b/device/uart-ns16550/uartInterrupt.c
@@ -15,7 +15,7 @@ extern int resdefer;
  *
  * Decode hardware interrupt request from UART device.
  */
-interrupt uartInterrupt(void)
+interrupt uartInterruptNoRsch(void)
 {
     int u = 0, iir = 0, lsr = 0, count = 0;
     char c;
@@ -124,10 +124,22 @@ interrupt uartInterrupt(void)
             break;
         }
     }
+}
 
-    if (--resdefer > 0)
-    {
-        resdefer = 0;
-        resched();
+/**
+ * @ingroup uarthardware
+ *
+ * Decode hardware interrupt request from UART device and call
+ * resched() if needed. Normally used as UART interrupt handler except
+ * on the architectures where devices share interrupts.
+ *
+ */
+interrupt uartInterrupt(void)
+{
+    uartInterruptNoRsch();
+    if (--resdefer > 0) 
+    { 
+	 resdefer = 0; 
+	 resched();
     }
 }

--- a/device/uart/kvprintf.c
+++ b/device/uart/kvprintf.c
@@ -33,7 +33,7 @@ syscall kvprintf(const char *format, va_list ap)
      * it prevents kprintf()'s from stepping on each other toes if you happen to
      * call kprintf() from an interrupt handler.  */
     im = disable();
-    retval = _doprnt(format, ap, (int (*)(int, int))kputc, (int)&devtab[SERIAL0]);
+    retval = _doprnt(format, ap, (int (*)(int, uintptr_t))kputc, (uintptr_t)&devtab[SERIAL0]);
     restore(im);
     return retval;
 }

--- a/include/dtb.h
+++ b/include/dtb.h
@@ -1,0 +1,26 @@
+/**
+ * @file dhcpc.h
+ *
+ * Devicetree parser interface
+ */
+/* Embedded Xinu, Copyright (C) 2018.  All rights reserved. */
+
+#ifndef _DTB_H_
+#define _DTB_H_
+
+
+/* parse dtb tree:
+   Arguments: pointer to the in-memory flat device tree
+              pointer to callback that will handle parsed properties
+	      pointer to callback that will handle reserved memory blocks
+*/              
+int parse_dtb(void *dtbptr,
+	      void (*prop_handler)(char *node_name,
+				   char *property_name,
+				   unsigned char *val,
+				   uint32_t len),
+	      void (*rsv_handler)(uint64_t address,
+				  uint64_t size));
+uint64_t dtb_read_uint64(uint32_t* dataptr);
+
+#endif

--- a/include/endianness.h
+++ b/include/endianness.h
@@ -23,6 +23,20 @@ bswap32(uint32_t n)
     return (n << 24) | ((n & 0xff00) << 8) | ((n & 0xff0000) >> 8) | (n >> 24);
 }
 
+static inline uint64_t
+bswap64(uint64_t n)
+{
+    return((n & 0xff00000000000000) >> 56)	
+	| ((n & 0x00ff000000000000) >> 40)	
+	| ((n & 0x0000ff0000000000) >> 24)	
+	| ((n & 0x000000ff00000000) >> 8)	
+	| ((n & 0x00000000ff000000) << 8)	
+	| ((n & 0x0000000000ff0000) << 24)	
+	| ((n & 0x000000000000ff00) << 40)	
+	| ((n & 0x00000000000000ff) << 56);
+}
+
+
 #if BYTE_ORDER == BIG_ENDIAN
 
 /* Big-endian CPU  */
@@ -30,14 +44,18 @@ bswap32(uint32_t n)
 /* big endian to big endian:  no-op  */
 #  define cpu_to_be16(n)  n
 #  define cpu_to_be32(n)  n
+#  define cpu_to_be64(n)  n
 #  define be16_to_cpu(n)  n
 #  define be32_to_cpu(n)  n
+#  define be64_to_cpu(n)  n
 
 /* big endian to little endian and vice versa  */
 #  define cpu_to_le16(n)  bswap16(n)
 #  define cpu_to_le32(n)  bswap32(n)
+#  define cpu_to_le64(n)  bswap64(n)
 #  define le16_to_cpu(n)  bswap16(n)
 #  define le32_to_cpu(n)  bswap32(n)
+#  define le64_to_cpu(n)  bswap64(n)
 
 #else /* BYTE_ORDER == BIG_ENDIAN */
 
@@ -46,14 +64,18 @@ bswap32(uint32_t n)
 /* little endian to big endian and vice versa  */
 #  define cpu_to_be16(n)  bswap16(n)
 #  define cpu_to_be32(n)  bswap32(n)
+#  define cpu_to_be64(n)  bswap64(n)
 #  define be16_to_cpu(n)  bswap16(n)
 #  define be32_to_cpu(n)  bswap32(n)
+#  define be64_to_cpu(n)  bswap64(n)
 
 /* little endian to little endian:  no-op  */
 #  define cpu_to_le16(n)  n
 #  define cpu_to_le32(n)  n
+#  define cpu_to_le64(n)  n
 #  define le16_to_cpu(n)  n
 #  define le32_to_cpu(n)  n
+#  define le64_to_cpu(n)  n    
 
 #endif /* BYTE_ORDER != BIG_ENDIAN */
 

--- a/include/limits.h
+++ b/include/limits.h
@@ -28,7 +28,11 @@
 #define INT_MIN   (-INT_MAX-1)  /**< minimum value of int               */
 #define UINT_MAX  (2U*INT_MAX+1) /**< maximum value of unsigned int     */
 
+#ifdef __LP64__  /* 64 bit arch */
+#define LONG_MAX  9223372036854775807L  /**< maximum value of long      */
+#else            /* 32 bit arch */
 #define LONG_MAX  2147483647    /**< maximum value of long              */
+#endif
 #define LONG_MIN  (-LONG_MAX-1) /**< minimum value of long              */
 #define ULONG_MAX (2UL*LONG_MAX+1) /**< maximum value of unsigned long  */
 

--- a/include/memory.h
+++ b/include/memory.h
@@ -9,11 +9,13 @@
 #define _MEMORY_H_
 
 #include <stddef.h>
+#include <stdint.h>
 
+#define MEMORY_DMBDEC (2*sizeof(uintptr_t)-1)
 /* roundmb - round address up to size of memblock  */
-#define roundmb(x)  (void *)( (7 + (ulong)(x)) & ~0x07 )
+#define roundmb(x)  (void *)( (MEMORY_DMBDEC + (ulong)(x)) & ~MEMORY_DMBDEC )
 /* truncmb - truncate address down to size of memblock */
-#define truncmb(x)  (void *)( ((ulong)(x)) & ~0x07 )
+#define truncmb(x)  (void *)( ((ulong)(x)) & ~MEMORY_DMBDEC )
 
 /**
  * @ingroup memory_mgmt
@@ -38,7 +40,7 @@
 struct memblock
 {
     struct memblock *next;          /**< pointer to next memory block       */
-    uint length;                    /**< size of memory block (with struct) */
+    uintptr_t length;                    /**< size of memory block (with struct) */
 };
 
 extern struct memblock memlist;     /**< head of free memory list           */
@@ -50,8 +52,8 @@ extern void *_etext;            /**< linker provides end of text segment    */
 extern void *memheap;           /**< bottom of heap                         */
 
 /* Memory function prototypes */
-void *memget(uint);
-syscall memfree(void *, uint);
-void *stkget(uint);
+void *memget(uintptr_t);
+syscall memfree(void *, uintptr_t);
+void *stkget(uintptr_t);
 
 #endif                          /* _MEMORY_H_ */

--- a/include/riscv.h
+++ b/include/riscv.h
@@ -1,0 +1,90 @@
+#ifndef RISCV_H
+#define RISCV_H
+
+/* RISC-V specific values and macros
+ *
+ * Derived from the RISC-V specification and from the spike (riscv-isa-sim) sources
+ * (the latter Copyright (c) 2010-2017, The Regents of the University of California)
+ *
+ */
+
+/* Machine status register bits */
+#define MSTATUS_UIE         0x00000001
+#define MSTATUS_SIE         0x00000002
+#define MSTATUS_HIE         0x00000004
+#define MSTATUS_MIE         0x00000008
+#define MSTATUS_UPIE        0x00000010
+#define MSTATUS_SPIE        0x00000020
+#define MSTATUS_HPIE        0x00000040
+#define MSTATUS_MPIE        0x00000080
+#define MSTATUS_SPP         0x00000100
+#define MSTATUS_HPP         0x00000600
+#define MSTATUS_MPP         0x00001800
+#define MSTATUS_FS          0x00006000
+#define MSTATUS_XS          0x00018000
+#define MSTATUS_MPRV        0x00020000
+#define MSTATUS_SUM         0x00040000
+#define MSTATUS_MXR         0x00080000
+#define MSTATUS_TVM         0x00100000
+#define MSTATUS_TW          0x00200000
+#define MSTATUS_TSR         0x00400000
+#define MSTATUS32_SD        0x80000000
+#define MSTATUS_UXL         0x0000000300000000
+#define MSTATUS_SXL         0x0000000C00000000
+#define MSTATUS64_SD        0x8000000000000000
+
+#if __riscv_xlen == 64
+# define MSTATUS_SD MSTATUS64_SD
+#else
+# define MSTATUS_SD MSTATUS32_SD
+#endif
+
+
+/* MIP and MIE registers bits */
+#define MIP_SSIP            (1 << IRQ_S_SOFT)
+#define MIP_MSIP            (1 << IRQ_M_SOFT)
+#define MIP_STIP            (1 << IRQ_S_TIMER)
+#define MIP_MTIP            (1 << IRQ_M_TIMER)
+#define MIP_SEIP            (1 << IRQ_S_EXT)
+#define MIP_MEIP            (1 << IRQ_M_EXT)
+
+/* Privilege modes */
+#define PRV_U 0
+#define PRV_S 1
+#define PRV_H 2
+#define PRV_M 3
+
+/* Interrupt bits for MIE, MIP and delegation registers */
+#define IRQ_S_SOFT   1
+#define IRQ_M_SOFT   3
+#define IRQ_S_TIMER  5
+#define IRQ_M_TIMER  7
+#define IRQ_S_EXT    9
+#define IRQ_M_EXT    11
+
+/* CSR access macros */
+#define write_csr(reg, val) ({ \
+  asm volatile ("csrw " #reg ", %0" :: "rK"(val)); })
+
+#define read_csr(reg) ({ unsigned long __tmp;	 \
+      asm volatile ("csrr %0, " #reg : "=r"(__tmp));	\
+      __tmp; })
+
+#define swap_csr(reg, val) ({ unsigned long __tmp; \
+  asm volatile ("csrrw %0, " #reg ", %1" : "=r"(__tmp) : "rK"(val)); \
+  __tmp; })
+
+#define set_csr(reg, bit) ({ unsigned long __tmp; \
+  asm volatile ("csrrs %0, " #reg ", %1" : "=r"(__tmp) : "rK"(bit)); \
+  __tmp; })
+
+#define clear_csr(reg, bit) ({ unsigned long __tmp; \
+  asm volatile ("csrrc %0, " #reg ", %1" : "=r"(__tmp) : "rK"(bit)); \
+  __tmp; })
+
+/*  Size of context to be saved: number of registers * bytes per reg */
+#define REGBYTES (__riscv_xlen / 8)
+#define  RISCV_CONTEXT_SIZE (32*REGBYTES)
+
+#endif /* RISCVH */
+

--- a/include/stdint.h
+++ b/include/stdint.h
@@ -18,4 +18,12 @@ typedef unsigned short       uint16_t;
 typedef unsigned int         uint32_t;
 typedef unsigned long long   uint64_t;
 
+#if __LP64__
+typedef long int             intptr_t;
+typedef unsigned long int    uintptr_t;
+#else
+typedef int                  intptr_t;
+typedef unsigned int         uintptr_t;
+#endif
+
 #endif /* _STDINT_H_ */

--- a/include/stdio.h
+++ b/include/stdio.h
@@ -6,6 +6,7 @@
 #ifndef _STDIO_H_
 #define _STDIO_H_
 
+#include <stdint.h>
 #include <compiler.h>
 #include <stdarg.h>
 #include <thread.h>  /* For thrtab and thrcurrent. */
@@ -31,8 +32,8 @@
 
 /* Formatted input  */
 int _doscan(const char *fmt, va_list ap,
-            int (*getch) (int, int), int (*ungetch) (int, int),
-            int arg1, int arg2);
+            int (*getch) (int, uintptr_t), int (*ungetch) (int, uintptr_t),
+            int arg1, uintptr_t arg2);
 
 int fscanf(int dev, const char *format, ...);
 
@@ -45,7 +46,7 @@ int sscanf(const char *str, const char *format, ...);
 
 /* Formatted output  */
 int _doprnt(const char *format, va_list,
-	    int (*putc_func)(int, int), int putc_arg);
+	    int (*putc_func)(int, uintptr_t), uintptr_t putc_arg);
 
 int fprintf(int dev, const char *format, ...) __printf_format(2, 3);
 int printf(const char *format, ...) __printf_format(1, 2);

--- a/include/uart.h
+++ b/include/uart.h
@@ -79,6 +79,7 @@ devcall uartGetc(device *);
 devcall uartPutc(device *, char);
 devcall uartControl(device *, int, long, long);
 interrupt uartInterrupt(void);
+interrupt uartInterruptNoRsch(void);
 void uartStat(ushort);
 
 /**

--- a/lib/libxc/doprnt.c
+++ b/lib/libxc/doprnt.c
@@ -84,7 +84,7 @@ enum integer_size {
  *      number of characters written on success, or @c EOF on failure
  */
 int _doprnt(const char *fmt, va_list ap,
-            int (*putc_func) (int, int), int putc_arg)
+            int (*putc_func) (int, uintptr_t), uintptr_t putc_arg)
 {
     int chars_written = 0;      /* Number of characters written so far  */
 

--- a/lib/libxc/doscan.c
+++ b/lib/libxc/doscan.c
@@ -20,15 +20,15 @@ enum integer_size {
 
 static int scan_string(char *ptr, int type, uint maxlen,
                        const uchar *stopchar_tab,
-                       int (*getch) (int, int), int (*ungetch) (int, int),
-                       int arg1, int arg2, bool *eofptr);
+                       int (*getch) (int, uintptr_t), int (*ungetch) (int, uintptr_t),
+                       int arg1, uintptr_t arg2, bool *eofptr);
 
 static int scan_number_or_string(void *ptr, uchar type, uint maxlen,
                                  enum integer_size size,
                                  const uchar *stopchar_tab,
-                                 int (*getch) (int, int),
-                                 int (*ungetch) (int, int),
-                                 int arg1, int arg2, bool *eofptr);
+                                 int (*getch) (int, uintptr_t),
+                                 int (*ungetch) (int, uintptr_t),
+                                 int arg1, uintptr_t arg2, bool *eofptr);
 
 static const uchar *build_stopchar_tab(const uchar *ufmt, uchar *stopchar_tab);
 
@@ -81,8 +81,8 @@ static const uchar *build_stopchar_tab(const uchar *ufmt, uchar *stopchar_tab);
  *      returned.
  */
 int _doscan(const char *fmt, va_list ap,
-            int (*getch) (int, int), int (*ungetch) (int, int),
-            int arg1, int arg2)
+            int (*getch) (int, uintptr_t), int (*ungetch) (int, uintptr_t),
+            int arg1, uintptr_t arg2)
 {
     int nmatch;
     uint maxlen;
@@ -235,8 +235,8 @@ int _doscan(const char *fmt, va_list ap,
 }
 
 static int scan_string(char *ptr, int type, uint maxlen, const uchar *stopchar_tab,
-                       int (*getch) (int, int), int (*ungetch) (int, int),
-                       int arg1, int arg2, bool *eofptr)
+                       int (*getch) (int, uintptr_t), int (*ungetch) (int, uintptr_t),
+                       int arg1, uintptr_t arg2, bool *eofptr)
 {
     uint len;
     int c;
@@ -290,9 +290,9 @@ static int scan_string(char *ptr, int type, uint maxlen, const uchar *stopchar_t
 static int scan_number_or_string(void *ptr, uchar type, uint maxlen,
                                  enum integer_size size,
                                  const uchar *stopchar_tab,
-                                 int (*getch) (int, int),
-                                 int (*ungetch) (int, int),
-                                 int arg1, int arg2, bool *eofptr)
+                                 int (*getch) (int, uintptr_t),
+                                 int (*ungetch) (int,uintptr_t),
+                                 int arg1, uintptr_t arg2, bool *eofptr)
 {
     int c = EOF;
     ulong n;

--- a/lib/libxc/fprintf.c
+++ b/lib/libxc/fprintf.c
@@ -30,7 +30,7 @@ int fprintf(int dev, const char *format, ...)
     int ret;
 
     va_start(ap, format);
-    ret = _doprnt(format, ap, fputc, dev);
+    ret = _doprnt(format, ap,  (int (*)(int,  uintptr_t)) fputc, (uintptr_t) dev);
     va_end(ap);
     return ret;
 }

--- a/lib/libxc/fscanf.c
+++ b/lib/libxc/fscanf.c
@@ -6,8 +6,8 @@
 #include <stdarg.h>
 #include <stdio.h>
 
-static int getch(int, int);
-static int ungetch(int, int);
+static int getch(int, uintptr_t);
+static int ungetch(int, uintptr_t);
 
 struct ch_buf
 {
@@ -44,14 +44,14 @@ int fscanf(int dev, const char *format, ...)
 
     buf.ch_avail = FALSE;
     va_start(ap, format);
-    ret = _doscan(format, ap, getch, ungetch, dev, (int)&buf);
+    ret = _doscan(format, ap, getch, ungetch, dev, (uintptr_t)&buf);
     va_end(ap);
     return ret;
 }
 
 /* Get a character from the device, storing it in the character buffer in case
  * an unget is requested.  */
-static int getch(int dev, int _ch_buf)
+static int getch(int dev, uintptr_t _ch_buf)
 {
     struct ch_buf *buf = (struct ch_buf *)_ch_buf;
     int c;
@@ -72,7 +72,7 @@ static int getch(int dev, int _ch_buf)
 }
 
 /* Put back a character.  */
-static int ungetch(int dev, int _chbuf)
+static int ungetch(int dev, uintptr_t _chbuf)
 {
     struct ch_buf *buf = (struct ch_buf *)_chbuf;
 

--- a/lib/libxc/malloc.c
+++ b/lib/libxc/malloc.c
@@ -35,7 +35,7 @@ void *malloc(size_t size)
 
     /* acquire memory from kernel */
     pmem = (struct memblock *)memget(size);
-    if (SYSERR == (uint)pmem)
+    if (SYSERR == (intptr_t)pmem)
     {
         return NULL;
     }

--- a/lib/libxc/printf.c
+++ b/lib/libxc/printf.c
@@ -28,7 +28,7 @@ int printf(const char *format, ...)
     int ret;
 
     va_start(ap, format);
-    ret = _doprnt(format, ap, fputc, stdout);
+    ret = _doprnt(format, ap,  (int (*)(int,  uintptr_t))  fputc, (uintptr_t)stdout);
     va_end(ap);
 
     return ret;

--- a/lib/libxc/sprintf.c
+++ b/lib/libxc/sprintf.c
@@ -6,7 +6,7 @@
 #include <stdarg.h>
 #include <stdio.h>
 
-static int sprntf(int, int);
+static int sprntf(int, uintptr_t);
 
 /**
  * @ingroup libxc
@@ -33,7 +33,7 @@ int sprintf(char *str, const char *format, ...)
 
     s = str;
     va_start(ap, format);
-    _doprnt(format, ap, sprntf, (int)&s);
+    _doprnt(format, ap, sprntf, (uintptr_t) &s);
     va_end(ap);
     *s = '\0';
 
@@ -43,7 +43,7 @@ int sprintf(char *str, const char *format, ...)
 /*
  * Routine called by _doprnt() to output each character.
  */
-static int sprntf(int c, int _sptr)
+static int sprntf(int c, uintptr_t _sptr)
 {
     char **sptr = (char **)_sptr;
     char *s = *sptr;

--- a/lib/libxc/sscanf.c
+++ b/lib/libxc/sscanf.c
@@ -8,8 +8,8 @@
 #include <stddef.h>
 #include <stdio.h>
 
-static int sgetch(int, int);
-static int sungetch(int, int);
+static int sgetch(int, uintptr_t);
+static int sungetch(int, uintptr_t);
 
 /**
  * @ingroup libxc
@@ -36,7 +36,7 @@ int sscanf(const char *str, const char *format, ...)
     int ret;
 
     va_start(ap, format);
-    ret = _doscan(format, ap, sgetch, sungetch, 0, (int)&str);
+    ret = _doscan(format, ap, sgetch, sungetch, 0, (uintptr_t) &str);
     va_end(ap);
 
     return ret;
@@ -45,7 +45,7 @@ int sscanf(const char *str, const char *format, ...)
 /* The first argument to the below functions is ignored, as we only need one
  * argument to specify the current position in the string.  */
 
-static int sgetch(int _ignored, int _str_p)
+static int sgetch(int _ignored, uintptr_t _str_p)
 {
     const char **str_p = (const char **)_str_p;
     const char *str = *str_p;
@@ -63,7 +63,7 @@ static int sgetch(int _ignored, int _str_p)
     return c;
 }
 
-static int sungetch(int _ignored, int _str_p)
+static int sungetch(int _ignored, uintptr_t _str_p)
 {
     const char **str_p = (const char**)_str_p;
     const char *str = *str_p;

--- a/loader/platforms/riscv64-qemu/Makerules
+++ b/loader/platforms/riscv64-qemu/Makerules
@@ -1,0 +1,10 @@
+# Name of this component (the directory this file is stored in)
+COMP = loader/platforms/riscv64-qemu
+
+# Source files for this component
+C_FILES =
+S_FILES = start.S
+
+# Add the files to the compile source path
+DIR = ${TOPDIR}/${COMP}
+COMP_SRC += ${S_FILES:%=${DIR}/%} ${C_FILES:%=${DIR}/%}

--- a/loader/platforms/riscv64-qemu/start.S
+++ b/loader/platforms/riscv64-qemu/start.S
@@ -1,0 +1,241 @@
+/**
+ * @file start.S
+ *
+ * Initialization code for Embedded Xinu on RISCV-QEMU virt board
+ *	
+ */
+	
+/* Embedded Xinu, Copyright (C) 2018.  All rights reserved. */
+
+
+#include <riscv.h>    
+
+// sizes for fixed stacks	
+#define NULLSTK   8192
+#define PANICSTK  8192
+
+
+.section .init
+	.globl _start
+
+	/* _start:  Entry point of the Xinu kernel */
+	.func _start
+_start:
+	j reset_handler
+	.endfunc
+
+.align 0x4
+        /* vector of interrupt and exception handlers, each entry is 4
+	bytes, so it can contain just one uncompressed or two
+	compressed instructions */
+_vectors:
+	/* 0: User software interrupt/Exception */
+	c.j exception_handler
+	c.nop
+	/* 1: Supervisor software interrupt */
+	c.j exception_handler
+	c.nop
+	/* 2: */
+	c.j exception_handler
+	c.nop
+	/* 3: Machine software interrupt */
+	c.j exception_handler
+	c.nop	
+	/* 4 User timer interrupt */
+	c.j exception_handler
+	c.nop
+	/* 5 Supervisor timer interrupt */
+	c.j exception_handler
+	c.nop	
+	/* 6 */
+	c.j exception_handler
+	c.nop
+	/* 7 Machine timer interrupt */
+	c.j mach_timer_int
+	c.nop
+	/* 8 User external interrupt */
+	c.j exception_handler
+	c.nop
+	/* 9 Supervisor external interrupt */
+	c.j exception_handler
+	c.nop
+	/* 10 Reserved */
+	c.j exception_handler
+	c.nop
+	/* 11 Machine external interrupt */
+	c.j mach_ext_int
+	c.nop
+	/* 12 - 15 reserved*/
+	c.j exception_handler
+	c.nop
+	c.j exception_handler
+	c.nop
+	c.j exception_handler
+	c.nop
+	c.j exception_handler
+	c.nop
+
+.macro SAVEREGS
+	addi sp,sp,-RISCV_CONTEXT_SIZE 
+	sd x1, 1*REGBYTES(sp)
+	sd x2, 2*REGBYTES(sp)	
+	sd x3, 3*REGBYTES(sp)
+	sd x4, 4*REGBYTES(sp)
+	sd x5, 5*REGBYTES(sp)
+	sd x6, 6*REGBYTES(sp)	
+	sd x7, 7*REGBYTES(sp)
+	sd x8, 8*REGBYTES(sp)	
+	sd x9, 9*REGBYTES(sp)	
+	sd x10, 10*REGBYTES(sp)	
+	sd x11, 11*REGBYTES(sp)	
+	sd x12, 12*REGBYTES(sp)	
+	sd x13, 13*REGBYTES(sp)	
+	sd x14, 14*REGBYTES(sp)	
+	sd x15, 15*REGBYTES(sp)	
+	sd x16, 16*REGBYTES(sp)	
+	sd x17, 17*REGBYTES(sp)	
+	sd x18, 18*REGBYTES(sp)	
+	sd x19, 19*REGBYTES(sp)	
+	sd x20, 20*REGBYTES(sp)	
+	sd x21, 21*REGBYTES(sp)	
+	sd x22, 22*REGBYTES(sp)	
+	sd x23, 23*REGBYTES(sp)	
+	sd x24, 24*REGBYTES(sp)	
+	sd x25, 25*REGBYTES(sp)	
+	sd x26, 26*REGBYTES(sp)	
+	sd x27, 27*REGBYTES(sp)	
+	sd x28, 28*REGBYTES(sp)	
+	sd x29, 29*REGBYTES(sp)	
+	sd x30, 30*REGBYTES(sp)	
+	sd x31, 31*REGBYTES(sp)
+
+	csrr t0, mepc
+	sd t0, 0(sp)
+.endm
+
+.macro RESTOREREGS
+	ld t0, 0(sp)
+	csrw mepc,t0
+
+	ld x1, 1*REGBYTES(sp)
+	ld x2, 2*REGBYTES(sp)	
+	ld x3, 3*REGBYTES(sp)
+	ld x4, 4*REGBYTES(sp)
+	ld x5, 5*REGBYTES(sp)
+	ld x6, 6*REGBYTES(sp)	
+	ld x7, 7*REGBYTES(sp)
+	ld x8, 8*REGBYTES(sp)	
+	ld x9, 9*REGBYTES(sp)	
+	ld x10, 10*REGBYTES(sp)	
+	ld x11, 11*REGBYTES(sp)	
+	ld x12, 12*REGBYTES(sp)	
+	ld x13, 13*REGBYTES(sp)	
+	ld x14, 14*REGBYTES(sp)	
+	ld x15, 15*REGBYTES(sp)	
+	ld x16, 16*REGBYTES(sp)	
+	ld x17, 17*REGBYTES(sp)	
+	ld x18, 18*REGBYTES(sp)	
+	ld x19, 19*REGBYTES(sp)	
+	ld x20, 20*REGBYTES(sp)	
+	ld x21, 21*REGBYTES(sp)	
+	ld x22, 22*REGBYTES(sp)	
+	ld x23, 23*REGBYTES(sp)	
+	ld x24, 24*REGBYTES(sp)	
+	ld x25, 25*REGBYTES(sp)	
+	ld x26, 26*REGBYTES(sp)	
+	ld x27, 27*REGBYTES(sp)	
+	ld x28, 28*REGBYTES(sp)	
+	ld x29, 29*REGBYTES(sp)	
+	ld x30, 30*REGBYTES(sp)	
+	ld x31, 31*REGBYTES(sp)	
+	addi sp,sp,RISCV_CONTEXT_SIZE
+.endm	
+	
+	/* external interrupt handler */
+mach_ext_int:
+	SAVEREGS		
+	jal dispatch
+	// make mret enable interrupts and stay in  Machine Mode
+	// (we may get here when process voluntary calls resched,
+	//  in this case MPP will be 0 (because no interrupt occured
+	//  and MPIE will be 1 (because resched() runs with interrupts
+	//  disbled
+	li t0, MSTATUS_MPP | MSTATUS_MPIE
+	csrs mstatus, t0
+	RESTOREREGS
+	mret
+
+mach_timer_int:
+	SAVEREGS			
+	jal dispatch_timer
+	// see comment above in mach_ext_int
+	li t0, MSTATUS_MPP | MSTATUS_MPIE
+	csrs mstatus, t0
+	RESTOREREGS
+	mret
+	
+exception_handler:
+	// pass orig. sp value as parameter
+	addi a0, sp, 0
+	// set sp to panic stack
+	la sp, panicstk
+	ld sp, 0(sp)
+	// jump to the C routine and stay there
+	j handle_exception
+	
+.section .text
+	/* reset_handler: Reset handler routine executed to start up the kernel
+	 * when the CPU processor is reset */
+	.func reset_handler
+reset_handler:
+	// disable all interrupts, clear pending interrupts
+	li a0, MSTATUS_MIE | MSTATUS_SIE | MSTATUS_MPIE | MSTATUS_SPIE
+	csrc mstatus, a0
+	//csrw mstatus, x0
+	csrw mie, x0
+	csrw mip, x0	
+
+	/* fill cpuid from misa:
+	 * misa is not exactly the unique cpu id (the (marchid, mvendorid) tuple is)
+	 * but it gives us isa variant in the bits [62,63]
+	 * and extensions list in the lowest 26 bits,
+	 */
+	csrr t1, misa
+	la   t0, cpuid
+	sd t1, 0(t0)
+	
+	// save dtb arrdess from a1
+	la   t0, dtb_addr
+	sd   a1, 0(t0)
+
+	/* interrupt vector setup */
+	/* write mtvec */
+	la t0, _vectors
+	// lower bit configures vectored interrupt mode
+	ori t0, t0, 1
+	csrw mtvec, t0
+check_mtvec:
+	/* Make sure it sticks: why do we need this? spike bug? */
+	csrr t1, mtvec
+        bne t0, t1, check_mtvec
+	
+	la sp, _end
+	/* Put the panick stack (used by exception handlers that 
+	 * prints the panic message with register dump)
+	 * directly after end of bss */
+	li t1, PANICSTK
+	add sp, sp, t1
+	la t0, panicstk
+	sd sp, 0(t0)
+	
+	/* Put the null thread's stack directly after the panic stack.  */	
+	li t1, NULLSTK
+	add sp, sp, t1
+	la t0, memheap
+	sd sp, 0(t0)
+	/* jump to the initialization routine */
+
+	j nulluser
+
+	.endfunc
+

--- a/mailbox/mailboxAlloc.c
+++ b/mailbox/mailboxAlloc.c
@@ -42,7 +42,7 @@ syscall mailboxAlloc(uint count)
             mbxptr->msgs = memget(sizeof(int) * count);
 
             /* check if memory was allocated correctly */
-            if (SYSERR == (int)mbxptr->msgs)
+            if (SYSERR == (intptr_t)mbxptr->msgs)
             {
                 break;
             }

--- a/system/Makerules
+++ b/system/Makerules
@@ -38,6 +38,9 @@ C_FILES += minijava.c
 # Files for reading tape archives
 C_FILES += tar.c
 
+# Files for reading device tree
+C_FILES += dtb.c
+
 # Add the files to the compile source path
 DIR = ${TOPDIR}/${COMP}
 COMP_SRC += ${C_FILES:%=${DIR}/%}

--- a/system/arch/riscv/ctxsw.S
+++ b/system/arch/riscv/ctxsw.S
@@ -1,0 +1,124 @@
+/**
+ * @file ctxsw.S
+ */
+/* Embedded Xinu, Copyright (C) 2013.  All rights reserved. */
+
+#include <riscv.h>
+
+.globl ctxsw
+
+/*------------------------------------------------------------------------
+ *  ctxsw  -  Switch from one thread context to another.
+ *------------------------------------------------------------------------
+ *
+ * This is the RISCV version.  How it works: we have to save s0-s11
+ * ra, and sp since s0-s11 are saved registers, ra  needs to be loaded into the
+ * pc when this context is switched to again. Registers a0-a7 are
+ * caller-save so they do not need not be saved, but they are pushed anyway
+ * since they are part of the context constructed by create() to pass thread arguments.
+ *
+ * We do not need to do anything about the CSRs here, since:
+ *
+ *   - We do all our context switches to/from the same mode (namely, Machine mode).
+ *   - The RISC-V ABI does not use CSRs
+ *   - resched() takes care of saving/restoring whether interrupts are enabled
+ *         or not when resuming a thread that has been switched out.
+ *   - Xinu never makes changes to the CSRs not already covered above
+ *
+ * However, interrupts are disabled when ctxsw() is called from resched(), but
+ * we want interrupts to be enabled when starting a *new* thread, which
+ * resched() does not take care of.  We solve this by including the machine status
+ * register value into the context and restoring it when we see that we're
+ * switching to the newly created thread
+ */
+
+ctxsw:
+	.func ctxsw
+	// reserve space
+	addi sp, sp, -REGBYTES*23
+	// save registers
+	sd a7, REGBYTES*22(sp)	
+	sd a6, REGBYTES*21(sp)	
+	sd a5, REGBYTES*20(sp)
+	sd a4, REGBYTES*19(sp)
+	sd a3, REGBYTES*18(sp)
+	sd a2, REGBYTES*17(sp)
+	sd a1, REGBYTES*16(sp)
+	sd a0, REGBYTES*15(sp)
+	sd s11, REGBYTES*14(sp)
+	sd s10, REGBYTES*13(sp)
+	sd s9, REGBYTES*12(sp)
+	sd s8, REGBYTES*11(sp)
+	sd s7, REGBYTES*10(sp)	
+	sd s6, REGBYTES*9(sp)
+	sd s5, REGBYTES*8(sp)
+	sd s4, REGBYTES*7(sp)
+	sd s3, REGBYTES*6(sp)
+	sd s2, REGBYTES*5(sp)
+	sd s1, REGBYTES*4(sp)
+	sd s0, REGBYTES*3(sp)
+	// save mstatus
+	csrr t2, mstatus
+	sd t2, REGBYTES*2(sp)
+	// we jump at end, jump address is different
+	// from return address only when switching to newly
+	// created context
+	sd ra,REGBYTES*1(sp)
+	sd ra,(sp)
+	//save modified sp at oldthr->stkptr
+	sd sp, (a0)
+	// get saved sp from newthrd->stkptr
+	ld sp, (a1)
+
+	// restore t0 <- saved jump address 
+	ld t0, (sp)
+	ld ra, REGBYTES*1(sp)
+	// t2 <- saved mstatus
+	ld t2, REGBYTES*2(sp)
+
+	// restore saved registers
+	ld s0, REGBYTES*3(sp)
+	ld s1, REGBYTES*4(sp)
+	ld s2, REGBYTES*5(sp)
+	ld s3, REGBYTES*6(sp)
+	ld s4, REGBYTES*7(sp)
+	ld s5, REGBYTES*8(sp)
+	ld s6, REGBYTES*9(sp)
+	ld s7, REGBYTES*10(sp)	
+	ld s8, REGBYTES*11(sp)
+	ld s9, REGBYTES*12(sp)
+	ld s10, REGBYTES*13(sp)
+	ld s11, REGBYTES*14(sp)
+
+	ld a0, REGBYTES*15(sp)
+	ld a1, REGBYTES*16(sp)
+	ld a2, REGBYTES*17(sp)
+	ld a3, REGBYTES*18(sp)
+	ld a4, REGBYTES*19(sp)
+	ld a5, REGBYTES*20(sp)
+	ld a6, REGBYTES*21(sp)	
+	ld a7, REGBYTES*22(sp)	
+
+	// restore sp
+	addi sp, sp, REGBYTES*23
+
+	// check if interrupts are disabled in saved mstatus
+	andi t3, t2, MSTATUS_MIE
+	beq t3,x0, end_ctxsw
+	// interrupts enabled (new thread)
+	// now tricky part: we restore mstatus as it was saved
+	// in the context _except_ the interrupt enable bit:
+	// t2 <- t2 & ~MSTATUS_MIE
+	andi t2, t2, -9
+	csrrw t2,  mstatus, t2
+	// load jump address to mepc
+	csrrw t1, mepc, t0
+	// mret will enable interrupts and
+	// jump to the newly created thread 
+	mret
+end_ctxsw:
+	// interrupts disabled: return to old thread
+	// pc is restored, next address is put into
+	// t1 and ignored
+	jalr t1,t0,0
+	.endfunc

--- a/system/arch/riscv/halt.S
+++ b/system/arch/riscv/halt.S
@@ -1,0 +1,20 @@
+/**
+ * @file halt.S
+ */
+/* Embedded Xinu, Copyright (C) 2018.  All rights reserved. */
+
+.globl halt
+
+/**
+ * @fn void halt(void)
+ *
+ * Halt the system by sending the processor into an infinite loop.
+ */
+halt:
+	.func halt
+
+_loop:
+	/* Wait for interrupt.  */
+	wfi
+	j _loop
+	.endfunc

--- a/system/arch/riscv/interrupt.h
+++ b/system/arch/riscv/interrupt.h
@@ -1,0 +1,27 @@
+/**
+ * @file interrupt.h
+ *
+ * Constants and declarations associated with interrupt handling.
+ */
+/* Embedded Xinu, Copyright (C) 2009, 2013.  All rights reserved. */
+ 
+#ifndef _RISCV_INTERRUPT_H_
+#define _RISCV_INTERRUPT_H_
+
+ 
+#include <stddef.h>
+
+typedef interrupt (*interrupt_handler_t)(void);
+
+extern interrupt_handler_t interruptVector[];
+
+typedef unsigned long irqmask;  /**< machine status for disable/restore  */
+
+
+void enable(void);
+irqmask disable(void);
+irqmask restore(irqmask);
+void enable_irq(irqmask);
+void disable_irq(irqmask);
+
+#endif /* _RISCV_INTERRUPT_H_ */

--- a/system/arch/riscv/intutils.S
+++ b/system/arch/riscv/intutils.S
@@ -1,0 +1,66 @@
+/**
+ * @file intutils.S
+ *
+ * Functions to enable, disable, or restore global interrupts on the RISC-V
+ *
+ */
+/* Embedded Xinu, Copyright (C) 2018.  All rights reserved. */
+#include <riscv.h>
+
+.globl enable
+.globl disable
+.globl restore
+
+/**
+ * @fn void enable(void)
+ *
+ * Enable interrupts globally.
+ */
+enable:
+	.func enable
+	csrrsi a0, mstatus, MSTATUS_MIE
+	ret
+	.endfunc
+
+/**
+ * @fn irqmask disable(void)
+ *
+ * Disable interrupts globally and returns the old state.
+ * @return state of interrupts before they were disabled:
+ *      0x0 - was enabled,
+ *	0x8 - if it was disabled
+ *	      (i.e. the inverse of the MIE bit)
+ *
+ */
+disable:
+	.func disable
+	csrrci a0, mstatus, MSTATUS_MIE
+	not a0,a0
+	andi a0,a0,MSTATUS_MIE
+        ret
+	.endfunc
+
+/**
+ * @fn irqmask restore(irqmask)
+ *
+ * Restores the global interrupt mask to a previous state.
+ * @param im
+ *     irqmask of interrupt state to restore:
+ *     0 - enable, not 0 - disable
+ * @return state of interrupts when called
+ */
+restore:
+	.func restore
+	// branch if is enable
+	beq a0,x0, restore_set_mie
+	csrrci a0, mstatus, MSTATUS_MIE
+	j restore_return
+restore_set_mie:
+	csrrsi a0, mstatus, MSTATUS_MIE
+restore_return:
+	not  a0, a0
+	andi a0, a0, MSTATUS_MIE
+	ret
+	.endfunc
+
+

--- a/system/arch/riscv/panic.c
+++ b/system/arch/riscv/panic.c
@@ -1,0 +1,24 @@
+/**
+ * @file panic.c
+ */
+/* Embedded Xinu, Copyright (C) 2018.  All rights reserved. */
+//#include <platform.h>
+#include <kernel.h>
+#include <riscv.h>
+
+extern __attribute__((noreturn)) void halt(void);
+
+/* panic message when caught exception that we cannot handle */
+void __attribute__((noreturn)) handle_exception(ulong sp)
+{
+    /* TODO: print all registers
+       decode cause codes */
+    kprintf("**** handle_exception  *****\n");
+    ulong cause = read_csr(mcause);
+    ulong tval = read_csr(mtval);
+    ulong mstatus = read_csr(mstatus);
+    kprintf("sp = 0x%lx mstatus=0x%lx\n", sp, mstatus);
+    kprintf("mcause = 0x%lx mtval=0x%lx\n", cause, tval);
+    kprintf("at addr mepc=%lx\n",read_csr(mepc));
+    halt();
+}

--- a/system/arch/riscv/pause.S
+++ b/system/arch/riscv/pause.S
@@ -1,0 +1,13 @@
+/**
+ * @file pause.S
+ * Platform-dependent code for idling the processor.
+ */
+/* Embedded Xinu, Copyright (C) 2018.  All rights reserved. */
+
+.globl pause
+
+pause:
+	.func pause
+	wfi  /* Wait For Interrupt instruction. */
+	ret
+	.endfunc

--- a/system/arch/riscv/riscvclk.c
+++ b/system/arch/riscv/riscvclk.c
@@ -1,0 +1,31 @@
+/**
+ * @file riscvclk.c
+ *
+ * Driver for the RISCV RTC timer. 
+ *
+ * The hardware interface is documented in the RISCV privileged
+ * architecture specification.  It looks that QEMU implementation is
+ * based on the SiFive: the CLINT offsets match those the SiFive U54
+ * Core Complex Manual
+ *
+ */
+/* Embedded Xinu, Copyright (C) 2018.  All rights reserved. */
+
+#include <clock.h>
+#include <stdint.h>
+#include <riscv.h>
+
+volatile uint64_t* mtime;
+volatile uint64_t* mtimecmp;
+
+/* clkcount() interface is documented in clock.h  */
+ulong clkcount(void)
+{
+    return *mtime;
+}
+
+/* clkupdate() interface is documented in clock.h  */
+void clkupdate(ulong cycles)
+{
+    *mtimecmp = (*mtime) + cycles;
+}

--- a/system/arch/riscv/setupStack.c
+++ b/system/arch/riscv/setupStack.c
@@ -1,0 +1,72 @@
+/**
+ * @file setupStack.c
+ */
+/* Embedded Xinu, Copyright (C) 2018.  All rights reserved. */
+
+#include <platform.h>
+#include <riscv.h>
+
+#define CONTEXT_WORDS 23
+
+/* First 8 arguments pass via a0-a7; the rest spill onto the stack.  */
+#define MAX_REG_ARGS 8
+
+/** Set up the context record and arguments on the stack for a new thread */
+void *setupStack(void *stackaddr, void *procaddr,
+                 void *retaddr, uint nargs, va_list ap)
+{
+    uint spilled_nargs;
+    ulong *saddr = stackaddr;
+
+    /* Determine if any arguments will spill onto the stack (outside the context
+     * record).  If so, reserve space for them.  */
+    if (nargs > MAX_REG_ARGS) {
+        spilled_nargs = nargs - MAX_REG_ARGS;
+        saddr -= spilled_nargs;
+    } else {
+        spilled_nargs = 0;
+    }
+
+    /* Construct the context record for the new thread.  */
+    saddr -= CONTEXT_WORDS;
+
+    /* Possibly skip a word to ensure the stack is aligned on 16-byte boundary
+     * after the new thread pops off the context record.  */
+    while ((ulong)saddr & 0xf)
+    {
+	saddr = (void*)((ulong)saddr) - 1;
+    }
+    uint i = 0;
+    /* Arguments passed in registers (part of context record)  */
+    /* program counter */
+    saddr[i++] = (ulong)procaddr;
+    /* x1 - return address */
+    saddr[i++] = (ulong)retaddr;
+    /* Interrupt enabled flag in mstatus set as well previous
+     * privilege mode to macine mode and previous interrupt enabled
+     * flag to true so mret could be used to properly restore the
+     * machine status as well as to jump to newly created thread
+     */
+    saddr[i++] = MSTATUS_MIE | MSTATUS_MPP | MSTATUS_MPIE;
+    /* s0 - s11 */
+    for (; i < 15 ; i++)
+    {
+        saddr[i] = 0;
+    }
+    
+    /* register arguments (as part of context) and rest of arguments
+     * that did not fit into the registers  */
+    for (int j=0; j < nargs; j++)
+    {
+        saddr[i++] = va_arg(ap, ulong);
+    }
+
+    /* rest of a registers (if any) */
+    for (; i < CONTEXT_WORDS ; i++)
+    {
+        saddr[i] = 0;
+    }
+
+    /* Return "top" of stack (lowest address). */
+    return saddr;
+}

--- a/system/create.c
+++ b/system/create.c
@@ -48,7 +48,7 @@ tid_typ create(void *procaddr, uint ssize, int priority,
 
     /* Allocate new stack.  */
     saddr = stkget(ssize);
-    if (SYSERR == (int)saddr)
+    if (SYSERR == (intptr_t)saddr)
     {
         restore(im);
         return SYSERR;

--- a/system/dtb.c
+++ b/system/dtb.c
@@ -1,0 +1,234 @@
+/**
+ * @file dtb.c This file provides support for parsing in-memory Flat
+ * Devicetree data structure.  For more information see the Devicetree
+ * Specification at https://www.devicetree.org/
+ */
+
+/* Embedded Xinu, Copyright (C) 2009.  All rights reserved. */
+
+#include <stddef.h>
+#include <device.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include <endianness.h>
+
+#define FDT_MAGIC  0xd00dfeed
+#define FDT_LAST_COMP_VERSION  2
+
+/* print the tree as it's being parsed */
+#define FDT_DETAILS 0
+
+#if FDT_DETAILS
+#define dtb_debug(format, ...) kprintf (format, ##__VA_ARGS__)
+#else
+#define dtb_debug(format, ...) 
+#endif
+
+struct fdt_header {
+    uint32_t magic;
+    uint32_t totalsize;
+    uint32_t off_dt_struct;
+    uint32_t off_dt_strings;
+    uint32_t off_mem_rsvmap;
+    uint32_t version;
+    uint32_t last_comp_version;
+    uint32_t boot_cpuid_phys; 
+    uint32_t size_dt_strings;
+    uint32_t size_dt_struct;
+}; 
+
+struct fdt_reserve_entry {
+    uint64_t address;
+    uint64_t size; 
+}; 
+
+void process_rsvmap(struct fdt_reserve_entry* eptr,
+		    void (*rsv_handler)(uint64_t address,
+					uint64_t size)) {
+    while ( eptr->address || eptr->size) {
+	dtb_debug("     protected region at %lX of size %lX",
+		  be64_to_cpu(eptr->address),
+		  be64_to_cpu(eptr->size));
+	if (NULL != rsv_handler) {
+	    rsv_handler(be64_to_cpu(eptr->address),
+			be64_to_cpu(eptr->address));
+	}
+	eptr++;
+    }
+}
+
+#define FDT_BEGIN_NODE 0x1
+#define FDT_END_NODE   0x2
+#define FDT_PROP       0x3
+#define FDT_NOP        0x4
+#define FDT_END        0x9
+
+
+
+
+struct fdt_prop {
+    uint32_t len;
+    uint32_t nameoff;
+};
+
+uint32_t c2ioff(uint32_t charoff) {
+    return (charoff / 4) + ((charoff % 4) ? 1 : 0);
+}
+
+#if FDT_DETAILS
+/* known properties that we know how to interpret */
+static char* fdt_string_prop_names[] = {"bootargs",
+					"compatible",
+					"device_type",
+					"stdout-path",
+					"stdin-path",
+					"model",
+					"status",
+					"name",
+					"mmu-type",
+					"riscv,isa",
+					NULL};
+static char* fdt_u32_prop_names[] = {"reg",
+				     "timebase-frequency",
+				     "phandle",
+				     "interrupts",
+				     "interrupt-parent",
+				     "#address-cells",
+				     "#size-cell",
+				     "clock-frequency",
+				     NULL};
+
+
+int fdt_prop_in_list(char* prop, char**lst) {
+    int i;
+    for(i = 0; NULL!= *(lst+i); i++) {
+	if (!strcmp(prop, *(lst+i))) {
+	    return 1;
+	}
+    }
+    return 0;
+}
+
+void fdt_print_prop(char* node_name,
+		    char *prop_name,
+		    unsigned char *prop_val,
+		    uint32_t prop_len) {
+    dtb_debug("     node=%s prop_name='%s' len=%u%s",
+	    node_name, prop_name, prop_len, (prop_len ? " value=" : ""));
+    // how do we know data type? only by name?
+    int j;
+    if (fdt_prop_in_list(prop_name, fdt_string_prop_names)) {
+	dtb_debug("'%s'", prop_val);
+    } else if (fdt_prop_in_list(prop_name, fdt_u32_prop_names)) {
+	dtb_debug("<");
+	for (j = 0 ; j < prop_len; j+=4) {
+	    dtb_debug("%s0x%x",
+		    (j ? " " : ""),
+		    be32_to_cpu(*((uint32_t*)(prop_val + j))));
+	}
+	dtb_debug(">");
+    } else {
+	for (j = 0 ; j < prop_len; j++) {
+	    dtb_debug("%s%02x", (j ? " " : ""), *(prop_val + j));
+	}
+    }
+    dtb_debug("\n");
+}
+#endif
+
+int process_fdt_nodes(void* fdt_strb_ptr, uint32_t *startptr,
+		      void (*handler)(char* nname,
+				      char *pname,
+				      unsigned char *val,
+				      uint32_t len)) {
+    uint32_t i = 0;
+    char *node_name = NULL;
+    while (1) {
+	//dtb_debug("  process_fdt_nodes: offset=%0u\n", i);
+	uint32_t*tokptr = startptr + i;
+	//dtb_debug("  process_fdt_nodes: tokptr 0x%lX\n", tokptr);
+	uint32_t token = be32_to_cpu(*tokptr);
+	//dtb_debug("  process_fdt_nodes: token=0x%X\n", token);
+	switch(token) {
+	case FDT_BEGIN_NODE:
+	    // FDT_BEGIN_NODE followed by 0 term. name
+	    node_name = (char*)(tokptr+1);
+	    dtb_debug("  begin node at %lX: '%s'\n", tokptr, node_name);
+	    i += 1 + c2ioff(1 + strlen((char*)(tokptr+1)));
+	    continue;
+	case FDT_PROP:
+	    ; /* ; keeps compiler happy, var decls aren't statements
+		 and can't be labeled */
+	    struct fdt_prop *propptr = (struct fdt_prop*)(tokptr+1);
+	    uint32_t prop_len = be32_to_cpu(propptr->len);
+	    char *prop_name = (char*)(fdt_strb_ptr + be32_to_cpu(propptr->nameoff));
+	    unsigned char *prop_val = ((unsigned char*)propptr) + sizeof(struct fdt_prop);
+#if FDT_DETAILS
+	    fdt_print_prop(node_name, prop_name, prop_val, prop_len);
+#endif	    
+	    if (NULL != handler) {
+		handler(node_name, prop_name, prop_val, prop_len);
+	    }
+	    i+= 1 + c2ioff(sizeof(struct fdt_prop) + prop_len);
+	    
+	    continue;
+	case FDT_END_NODE:
+	    node_name = NULL;
+	case FDT_NOP:
+	    i++;
+	    continue;
+	case FDT_END:
+	    dtb_debug("  FDT end at %lX\n", tokptr);
+	    return 0;
+	default:
+	    dtb_debug("  unknown token '%x' at %lX\n", token, tokptr+i);
+	    return 1;
+	}
+    
+    }
+    return 0;
+}
+
+
+int parse_dtb(void *dtbptr,
+	      void (*prop_handler)(char *nname,
+				   char *pname,
+				   unsigned char *val,
+				   uint32_t len),
+	      void (*rsv_handler)(uint64_t address,
+				  uint64_t size)) {
+    struct fdt_header* h = (struct fdt_header*)dtbptr;
+    dtb_debug("* Dump of dtb at 0x%0lX\n", dtbptr);
+    dtb_debug("  magic: 0x%x\n", be32_to_cpu(h->magic));
+    if (FDT_MAGIC!=be32_to_cpu(h->magic)) {
+	dtb_debug("Error: magic is invalid: got 0x%X, but 0x%X was expected\n",
+		h->magic, FDT_MAGIC);
+	return SYSERR;
+    }
+    dtb_debug("  version: %u\n", be32_to_cpu(h->version));
+    int lcompver = be32_to_cpu(h->last_comp_version);
+    dtb_debug("  last compatible version: %u\n", lcompver);
+    if (lcompver < FDT_LAST_COMP_VERSION) {
+	dtb_debug("WARNING: unexpected last_comp_version: got %u, but only %u is supported, parsing mail fail!",
+		lcompver, FDT_LAST_COMP_VERSION);
+    }
+    dtb_debug("  memory reservations map is at offset: 0x%x\n", be32_to_cpu(h->off_mem_rsvmap));
+    process_rsvmap((struct fdt_reserve_entry*)(dtbptr + be32_to_cpu(h->off_mem_rsvmap)),
+		   rsv_handler);
+    dtb_debug("  structure block is at offset: 0x%x\n", be32_to_cpu(h->off_dt_struct));
+    dtb_debug("  strings block is at offset: 0x%x\n", be32_to_cpu(h->off_dt_strings));
+    process_fdt_nodes((void*) (dtbptr + be32_to_cpu(h->off_dt_strings)),
+		      (uint32_t*)(dtbptr+ be32_to_cpu(h->off_dt_struct)),
+		      prop_handler);
+    return 0;
+}
+
+uint64_t dtb_read_uint64(uint32_t* dataptr) {
+    return ((((uint64_t)be32_to_cpu(*dataptr))<<32) | ((uint64_t)be32_to_cpu(*(dataptr+1))));
+}
+
+
+
+

--- a/system/initialize.c
+++ b/system/initialize.c
@@ -106,9 +106,9 @@ static int sysinit(void)
     memheap = roundmb(memheap);
     platform.maxaddr = truncmb(platform.maxaddr);
     memlist.next = pmblock = (struct memblock *)memheap;
-    memlist.length = (uint)(platform.maxaddr - memheap);
+    memlist.length = (uintptr_t)(platform.maxaddr - memheap);
     pmblock->next = NULL;
-    pmblock->length = (uint)(platform.maxaddr - memheap);
+    pmblock->length = (uintptr_t)(platform.maxaddr - memheap);
 
     /* Initialize thread table */
     for (i = 0; i < NTHREAD; i++)

--- a/system/main.c
+++ b/system/main.c
@@ -129,6 +129,19 @@ thread main(void)
     return 0;
 }
 
+
+#ifdef DETAIL
+extern ulong cpuid;
+#endif
+
+#if __LP64__
+#define HEXWIDTH 16
+#define DECWIDTH 20
+#else
+#define HEXWIDTH 8
+#define DECWIDTH 10
+#endif
+
 /* Start of kernel in memory (provided by linker)  */
 extern void _start(void);
 
@@ -139,44 +152,49 @@ static void print_os_info(void)
 
 #ifdef DETAIL
     /* Output detected platform. */
-    kprintf("Processor identification: 0x%08X\r\n", cpuid);
+    kprintf("Processor identification: 0x%lX\r\n", cpuid);
     kprintf("Detected platform as: %s, %s\r\n\r\n",
             platform.family, platform.name);
 #endif
 
     /* Output Xinu memory layout */
-    kprintf("%10d bytes physical memory.\r\n",
-            (ulong)platform.maxaddr - (ulong)platform.minaddr);
+    kprintf("%*ld bytes physical memory.\r\n",
+	    DECWIDTH, (uintptr_t)platform.maxaddr - (uintptr_t)platform.minaddr);
 #ifdef DETAIL
-    kprintf("           [0x%08X to 0x%08X]\r\n",
-            (ulong)platform.minaddr, (ulong)(platform.maxaddr - 1));
+    kprintf("           [0x%0*X to 0x%0*X]\r\n",
+	    HEXWIDTH, (uintptr_t)platform.minaddr,
+	    HEXWIDTH, (uintptr_t)(platform.maxaddr - 1));
 #endif
 
-
-    kprintf("%10d bytes reserved system area.\r\n",
-            (ulong)_start - (ulong)platform.minaddr);
+    kprintf("%*ld bytes reserved system area.\r\n",
+	    DECWIDTH, (uintptr_t)_start - (uintptr_t)platform.minaddr);
 #ifdef DETAIL
-    kprintf("           [0x%08X to 0x%08X]\r\n",
-            (ulong)platform.minaddr, (ulong)_start - 1);
+    kprintf("           [0x%0*lX to 0x%0*lX]\r\n", 
+	    HEXWIDTH, (uintptr_t)platform.minaddr,
+	    HEXWIDTH, (uintptr_t)_start - 1);
 #endif
 
-    kprintf("%10d bytes Xinu code.\r\n", (ulong)&_etext - (ulong)_start);
+    kprintf("%*ld bytes Xinu code.\r\n", DECWIDTH, (uintptr_t)&_etext - (uintptr_t)_start);
 #ifdef DETAIL
-    kprintf("           [0x%08X to 0x%08X]\r\n",
-            (ulong)_start, (ulong)&_end - 1);
+    kprintf("           [0x%0*lX to 0x%0*lX]\r\n",
+	    HEXWIDTH, (uintptr_t)_start,
+	    HEXWIDTH, (uintptr_t)&_end - 1);
 #endif
 
-    kprintf("%10d bytes stack space.\r\n", (ulong)memheap - (ulong)&_end);
+    kprintf("%*ld bytes stack space.\r\n",
+	    DECWIDTH, (uintptr_t)memheap - (uintptr_t)&_end);
 #ifdef DETAIL
-    kprintf("           [0x%08X to 0x%08X]\r\n",
-            (ulong)&_end, (ulong)memheap - 1);
+    kprintf("           [0x%0*lX to 0x%0*lX]\r\n",
+	    HEXWIDTH, (uintptr_t)&_end,
+	    HEXWIDTH, (uintptr_t)memheap - 1);
 #endif
 
-    kprintf("%10d bytes heap space.\r\n",
-            (ulong)platform.maxaddr - (ulong)memheap);
+    kprintf("%*ld bytes heap space.\r\n",
+            DECWIDTH, (uintptr_t)platform.maxaddr - (uintptr_t)memheap);
 #ifdef DETAIL
-    kprintf("           [0x%08X to 0x%08X]\r\n\r\n",
-            (ulong)memheap, (ulong)platform.maxaddr - 1);
+    kprintf("           [0x%0*lX to 0x%0*lX]\r\n\r\n",
+	    HEXWIDTH, (uintptr_t)memheap,
+	    HEXWIDTH, (uintptr_t)platform.maxaddr - 1);
 #endif
     kprintf("\r\n");
 }

--- a/system/memfree.c
+++ b/system/memfree.c
@@ -23,7 +23,7 @@
  *      ::OK on success; ::SYSERR on failure.  This function can only fail
  *      because of memory corruption or specifying an invalid memory block.
  */
-syscall memfree(void *memptr, uint nbytes)
+syscall memfree(void *memptr, uintptr_t nbytes)
 {
     register struct memblock *block, *next, *prev;
     irqmask im;

--- a/system/memget.c
+++ b/system/memget.c
@@ -21,7 +21,7 @@
  *      The returned pointer is guaranteed to be 8-byte aligned.  Free the block
  *      with memfree() when done with it.
  */
-void *memget(uint nbytes)
+void *memget(uintptr_t nbytes)
 {
     register struct memblock *prev, *curr, *leftover;
     irqmask im;

--- a/system/platforms/riscv64-qemu/Makerules
+++ b/system/platforms/riscv64-qemu/Makerules
@@ -1,0 +1,20 @@
+# Rules to build files in this directory
+
+# Name of this component (the directory this file is stored in)
+COMP = system/platforms/riscv64-qemu
+
+# Source files for this component
+S_FILES = intutils.S  \
+	pause.S \
+	halt.S \
+	ctxsw.S		
+
+C_FILES = panic.c \
+	platforminit.c \
+	plic.c \
+	riscvclk.c \
+	setupStack.c 
+
+# Add the files to the compile source path
+DIR = ${TOPDIR}/${COMP}
+COMP_SRC += ${S_FILES:%=${DIR}/%} ${C_FILES:%=${DIR}/%}

--- a/system/platforms/riscv64-qemu/ctxsw.S
+++ b/system/platforms/riscv64-qemu/ctxsw.S
@@ -1,0 +1,1 @@
+#include <system/arch/riscv/ctxsw.S>

--- a/system/platforms/riscv64-qemu/halt.S
+++ b/system/platforms/riscv64-qemu/halt.S
@@ -1,0 +1,1 @@
+#include <system/arch/riscv/halt.S>

--- a/system/platforms/riscv64-qemu/interrupt.h
+++ b/system/platforms/riscv64-qemu/interrupt.h
@@ -1,0 +1,13 @@
+/**
+ * @file interrupt.h
+ *
+ * Constants and declarations associated with interrupt handling.
+ */
+/* Embedded Xinu, Copyright (C) 2009, 2013.  All rights reserved. */
+ 
+#ifndef _INTERRUPT_H_
+#define _INTERRUPT_H_
+
+#include <system/arch/riscv/interrupt.h> 
+
+#endif /* _INTERRUPT_H_ */

--- a/system/platforms/riscv64-qemu/intutils.S
+++ b/system/platforms/riscv64-qemu/intutils.S
@@ -1,0 +1,9 @@
+/**
+ * @file intutils.S
+ *
+ * Functions to enable, disable, or restore global interrupts on the RISC-V
+ *
+ */
+/* Embedded Xinu, Copyright (C) 2018.  All rights reserved. */
+#include <system/arch/riscv/intutils.S>
+

--- a/system/platforms/riscv64-qemu/panic.c
+++ b/system/platforms/riscv64-qemu/panic.c
@@ -1,0 +1,1 @@
+#include <system/arch/riscv/panic.c>

--- a/system/platforms/riscv64-qemu/pause.S
+++ b/system/platforms/riscv64-qemu/pause.S
@@ -1,0 +1,1 @@
+#include <system/arch/riscv/pause.S>

--- a/system/platforms/riscv64-qemu/platforminit.c
+++ b/system/platforms/riscv64-qemu/platforminit.c
@@ -1,0 +1,180 @@
+/**
+ * @file platforminit.c
+ */
+/* Embedded Xinu, Copyright (C) 2018.  All rights reserved. */
+
+#include <platform.h>
+#include <string.h>
+#include <stdint.h>
+#include <kernel.h>
+#include <endianness.h>
+#include <riscv.h>
+#include <dtb.h>
+
+/**
+ * RISCV QEMU hardware platform specific initialization 
+ *
+ * @return OK
+ */
+
+void *dtb_addr;
+void *panicstk; 
+void* clint_base = NULL;
+
+extern void* plic_base;
+extern void plic_init(void);
+
+extern volatile uint64_t* mtime;
+extern volatile uint64_t* mtimecmp;
+
+
+#ifndef PLATFORMINIT_DETAIL
+#define PLATFORMINIT_DETAIL 0
+#endif
+
+#if PLATFORMINIT_DETAIL
+#define plinit_debug(format, ...) kprintf (format, ##__VA_ARGS__)
+#else
+#define plinit_debug(format, ...) 
+#endif
+
+
+void dtb_handler(char *nname,
+		 char *pname,
+		 unsigned char *val,
+		 uint32_t len);
+void apply_defaults(void);
+
+int platforminit(void)
+{
+    plinit_debug("platformInit: enter\n");
+    strlcpy(platform.family, "riscv64", PLT_STRMAX);
+    strlcpy(platform.name, "riscv64 qemu virt", PLT_STRMAX);
+   
+#if PLATFORMINIT_DETAIL
+    /* TODO: configure context switching code on basis of supported extensions,
+       so far we do not support switching anything but base ISA registers */
+    plinit_debug("platformInit: RISCV extensions supported: "); 
+    int misa = read_csr(misa);
+    int j;
+    // extension names are ASCII letters correspondings to bit offsets
+    for (j = 0; j < 26; j++) {
+	if (misa & (1 << j)) {
+	    plinit_debug("%c", 'A' + j);
+	}
+    }
+    plinit_debug("\n");
+#endif
+
+    plinit_debug("dtb is at %0lx\n", dtb_addr);
+    /* configure platfortm parameters from DeviceTree */
+    parse_dtb(dtb_addr, dtb_handler, NULL);
+    /* apply defaults for those parameters that were not set */
+    apply_defaults();
+
+    /* set timer registers offsets on core interrupter offset */
+    mtime = (uint64_t*)(clint_base + 0xbff8);
+    mtimecmp = (uint64_t*)(clint_base + 0x4000);
+    // not used on RISC-V
+    platform.serial_low = 0;   
+    platform.serial_high = 0;
+
+    /* initialize external and timer interrupts handling */
+    plic_init();
+    plinit_debug("platformInit: finished\n");
+    return OK;
+}
+
+void mem_dtb_handler(char *nname,
+		 char *pname,
+		 unsigned char *val,
+		 uint32_t len) {
+    if ((!platform.maxaddr) &&
+	(!strncmp(nname,"memory@",7)) &&
+	(!strcmp(pname,"reg")) &&
+	(len == 16)) {
+	uint *dataptr = (uint32_t*)val;
+	plinit_debug("mem_dtb_handler: setting memory size from dtb property %s/%s\n", nname, pname);
+	platform.minaddr = (void*) dtb_read_uint64(dataptr);
+	platform.maxaddr = (void*) platform.minaddr + dtb_read_uint64(dataptr + 2);
+	plinit_debug("mem_dtb_handler: minaddr=0x%lX maxaddr=0x%lX\n", platform.minaddr, platform.maxaddr);
+    }
+}
+
+void freq_dtb_handler(char *nname,
+		      char *pname,
+		      unsigned char *val,
+		      uint32_t len) {
+    if ((!platform.clkfreq) &&
+	(!strcmp(nname,"cpus")) &&
+	(!strcmp(pname,"timebase-frequency")) &&
+	(len == 4)) {
+	plinit_debug("freq_dtb_handler: clock frequency from dtb property %s/%s\n", nname, pname);
+	platform.clkfreq = (uint64_t) be32_to_cpu(*((uint32_t*) val));
+	plinit_debug("freq_dtb_handler: clock frequency set to %ld\n", platform.clkfreq);
+    }
+}
+
+void clint_dtb_handler(char *nname,
+		 char *pname,
+		 unsigned char *val,
+		 uint32_t len) {
+    if ((!clint_base) &&
+	(!strncmp(nname,"clint@",6)) &&
+	(!strcmp(pname,"reg")) &&
+	(len == 16)) {
+	plinit_debug("clint_dtb_handler: setting CLINT offset from dtb property %s/%s\n", nname, pname);
+	clint_base = (void*) dtb_read_uint64((uint32_t*)val);
+	plinit_debug("clint_dtb_handler: CLINT is at  0x%lx\n", clint_base);
+    }
+}
+
+void plic_dtb_handler(char *nname,
+		 char *pname,
+		 unsigned char *val,
+		 uint32_t len) {
+    if ((!plic_base) &&
+	(!strncmp(nname,"interrupt-controller@",6)) &&
+	(!strcmp(pname,"reg")) &&
+	(len == 16)) {
+	plinit_debug("plic_dtb_handler: setting PLIC offset from dtb property %s/%s\n", nname, pname);
+	plic_base = (void*) dtb_read_uint64((uint32_t*)val);
+	plinit_debug("plic_dtb_handler: PLIC is at  0x%lx\n", plic_base);
+    }
+}
+
+
+
+void dtb_handler(char *nname,
+		 char *pname,
+		 unsigned char *val,
+		 uint32_t len) {
+    mem_dtb_handler(nname, pname, val, len);
+    freq_dtb_handler(nname, pname, val, len);
+    clint_dtb_handler(nname, pname, val, len);
+    plic_dtb_handler(nname, pname, val, len);
+}
+
+void apply_defaults() {
+    /* set default values in case devicetree parsing did not work (should not happen) */
+    if (!platform.maxaddr) { 
+	plinit_debug("platformInit: using fallback memory configuration\n"); 
+	platform.minaddr = (void *) 0x80000000;
+	platform.maxaddr = (void *) 0x87FFFFFF; 
+    }                                  
+    if (!platform.clkfreq) {
+	platform.clkfreq = 10000000;
+	plinit_debug("platformInit: using fallback clock frequency: %ld\n",platform.clkfreq); 
+    }
+    if (! clint_base) {
+	clint_base = (void*) 0x2000000;
+	plinit_debug("platformInit: using fallback CLINT base address is at 0x%lX\n", clint_base); 
+    }
+    if (! plic_base) {
+	plic_base = (void*) 0xc000000;
+	plinit_debug("platformInit: using fallback PLIC base address is at 0x%lX\n", plic_base); 
+    }
+}
+    
+
+

--- a/system/platforms/riscv64-qemu/plic.c
+++ b/system/platforms/riscv64-qemu/plic.c
@@ -1,0 +1,121 @@
+/**
+ * @file pl190.c
+ *
+ * Driver for RISCV Platform-Level Interrupt Controller (PLIC)
+ * (see the RISC-V privileged architecture spec)
+ *
+ */
+/* Embedded Xinu, Copyright (C) 2014.  All rights reserved. */
+
+#include <riscv.h>
+#include <interrupt.h>
+#include <stdint.h>
+#include <thread.h>
+
+extern int resdefer;
+void* plic_base = NULL;
+
+// riscv PLIC supports 128 interrupts starting from 1,
+// IRQ ID 0 is unused, so we'll use irq 0 for handling timer interrupts
+interrupt_handler_t interruptVector[129];
+
+/* offset valus on basis of the SiFive U54 Core docs */
+#define PLIC_IRQ_PRI          (plic_base)
+#define PLIC_IRQ_ENABLE       (plic_base + 0x002000L)
+#define PLIC_IRQ_THRESHOLD    (plic_base + 0x200000L)
+#define PLIC_IRQ_CLAIM        (plic_base + 0x200004L)
+#define PLIC_IRQ_PENDING      (plic_base + 0x001000L)
+
+void plic_enable_irq(int num) {
+    *(((volatile uint32_t*)PLIC_IRQ_ENABLE)) |= (0x1 << num);
+}
+
+void plic_disable_irq(int num) {
+    *(((volatile uint32_t*)PLIC_IRQ_ENABLE)) &= ~(0x1 << num);
+}
+
+void plic_init(void) {
+    int i;
+    // Clear interrupt pending and interrupt enable bits.  The first
+    // bit of the first word is unused (non existing irq 0), just one
+    // bit is used in the last word for irq 128
+    for (i = 0; i < 5; i++) {
+	*((volatile uint32_t*)(PLIC_IRQ_ENABLE + (i << 2))) = 0;
+	*((volatile uint32_t*)(PLIC_IRQ_PENDING + (i << 2))) = 0;
+    }
+    // priority registers are 32 bit
+    for (i = 1; i <= 128; i++) {
+	// highest priority for all
+	*((volatile uint32_t*)(PLIC_IRQ_PRI  + i)) = 0x07;
+    }
+    // interrupts with priority > than threshold will trigger
+    *((volatile uint32_t*)PLIC_IRQ_THRESHOLD)=0x0;
+    // enable external interrupts
+    set_csr(mie, MIP_MEIP);
+}
+
+
+/**
+ * Enable an interrupt request line.
+ *
+ * @param irq
+ *      Number of the IRQ to enable, which on this platform must be in the
+ *      range [0, 31].
+ * 
+ * PLIC does not really have  IRQ0 (IRQ ID 0 means no interrupt), so
+ * in XINU we logically map IRQ number to RISCV timer interrupt, which
+ * is handled in  CLINT
+ */
+void enable_irq(irqmask irq)
+{
+  if (irq) {
+      plic_enable_irq(irq);
+  } else {
+      //enable timer interrupt
+      set_csr(mie, MIP_MTIP);
+  }
+}
+
+/**
+ * Disable an interrupt request line.
+ *
+ * @param irq
+ *      Number of the IRQ to disable, which on this platform must be in the
+ *      range [0, 31].
+ */
+void disable_irq(irqmask irq)
+{
+  if (irq) {
+      plic_disable_irq(irq);
+  } else {
+      //disable timer interrupt
+      clear_csr(mie, MIP_MTIP);
+  }
+}
+
+
+void dispatch_timer(void)
+{
+    interruptVector[0]();
+}
+
+/**
+ * Call the service routine for each pending IRQ, after this 
+ * reschedule if needed.
+ */
+void dispatch(void) {
+    int irq;
+    // get pending irq of maximum priority
+    while ((irq = *(((volatile uint32_t*)PLIC_IRQ_CLAIM)))) {
+	// handle it
+	interruptVector[irq]();
+	// clear claim
+	*(((volatile uint32_t*)PLIC_IRQ_CLAIM)) = irq;
+    }
+    if (--resdefer > 0)
+    {
+        resdefer = 0;
+	resched();
+    }
+}
+

--- a/system/platforms/riscv64-qemu/riscvclk.c
+++ b/system/platforms/riscv64-qemu/riscvclk.c
@@ -1,0 +1,1 @@
+#include <system/arch/riscv/riscvclk.c>

--- a/system/platforms/riscv64-qemu/setupStack.c
+++ b/system/platforms/riscv64-qemu/setupStack.c
@@ -1,0 +1,6 @@
+/**
+ * @file setupStack.c
+ */
+/* Embedded Xinu, Copyright (C) 2018.  All rights reserved. */
+
+#include <system/arch/riscv/setupStack.c>

--- a/system/stkget.c
+++ b/system/stkget.c
@@ -24,7 +24,7 @@
  *      the base of a stack growing down.  Free the stack with stkfree() when
  *      done with it.
  */
-void *stkget(uint nbytes)
+void *stkget(uintptr_t nbytes)
 {
     irqmask im;
     struct memblock *prev, *next, *fits, *fitsprev;
@@ -35,7 +35,7 @@ void *stkget(uint nbytes)
     }
 
     /* round to multiple of memblock size   */
-    nbytes = (uint)roundmb(nbytes);
+    nbytes = (uintptr_t)roundmb(nbytes);
 
     im = disable();
 
@@ -76,5 +76,5 @@ void *stkget(uint nbytes)
 
     memlist.length -= nbytes;
     restore(im);
-    return (void *)((ulong)fits + nbytes - sizeof(int));
+    return (void *)((ulong)fits + nbytes - sizeof(void*));
 }

--- a/test/test_libStdio.c
+++ b/test/test_libStdio.c
@@ -235,7 +235,7 @@ static const struct {
     const char *format;
     const char *expected_output;
     uint nargs;
-    uint args[4]; /* Assumes all args are 4 bytes. */
+    uintptr_t args[4]; /* Assumes all args are 4 bytes. */
 } fprintf_specs[] = {
     { /* Empty string */
         .format = "",
@@ -247,7 +247,7 @@ static const struct {
         .format = "%s",
         .expected_output = "",
         .nargs = 1,
-        .args = {(uint)""},
+        .args = {(uintptr_t)""},
     },
     { /* Binary number */
         .format = "%b",
@@ -295,7 +295,7 @@ static const struct {
         .format = "%s",
         .expected_output = "aoeu",
         .nargs = 1,
-        .args = {(uint)"aoeu"},
+        .args = {(uintptr_t)"aoeu"},
     },
     { /* Null string */
         .format = "%s",
@@ -325,55 +325,55 @@ static const struct {
         .format = "%.5s",
         .expected_output = "trunc",
         .nargs = 1,
-        .args = {(uint)"truncate me"},
+        .args = {(uintptr_t)"truncate me"},
     },
     { /* Truncated string, max-width specified as vararg */
         .format = "%.*s",
         .expected_output = "trunc",
         .nargs = 2,
-        .args = {5, (uint)"truncate me"},
+        .args = {5, (uintptr_t)"truncate me"},
     },
     { /* Non-truncated string, negative max-width has no effect  */
         .format = "%.*s",
         .expected_output = "truncate me",
         .nargs = 2,
-        .args = {-1, (uint)"truncate me"},
+        .args = {-1, (uintptr_t)"truncate me"},
     },
     { /* Truncated string, implicit zero max-width   */
         .format = "%.s",
         .expected_output = "",
         .nargs = 1,
-        .args = {(uint)"truncate me"},
+        .args = {(uintptr_t)"truncate me"},
     },
     { /* Right justified string */
         .format = "%10s",
         .expected_output = "     right",
         .nargs = 1,
-        .args = {(uint)"right"},
+        .args = {(uintptr_t)"right"},
     },
     { /* Right justified string, min-width specified as vararg */
         .format = "%*s",
         .expected_output = "     right",
         .nargs = 2,
-        .args = {10, (uint)"right"},
+        .args = {10, (uintptr_t)"right"},
     },
     { /* Left justified string */
         .format = "%-8s",
         .expected_output = "left    ",
         .nargs = 1,
-        .args = {(uint)"left"},
+        .args = {(uintptr_t)"left"},
     },
     { /* Left justified string, min-width specified as vararg */
         .format = "%-*s",
         .expected_output = "left    ",
         .nargs = 2,
-        .args = {8, (uint)"left"},
+        .args = {8, (uintptr_t)"left"},
     },
     { /* Left justified string via negative min-width specified as vararg */
         .format = "%*s",
         .expected_output = "left    ",
         .nargs = 2,
-        .args = {-8, (uint)"left"},
+        .args = {-8, (uintptr_t)"left"},
     },
     { /* Negative integer */
         .format = "%d",
@@ -397,7 +397,7 @@ static const struct {
         .format = "%u",
         .expected_output = "2147483648",
         .nargs = 1,
-        .args = {(uint)INT_MAX + 1},
+        .args = {(uintptr_t)INT_MAX + 1},
     },
     { /* min width (left justified, overriding zero padding) */
         .format = "%-06d", /* '-' overrides '0' */
@@ -433,13 +433,13 @@ static const struct {
         .format = "%23s",
         .expected_output = "     ""     ""     ""     ""123",
         .nargs = 1,
-        .args = {(uint)"123"},
+        .args = {(uintptr_t)"123"},
     },
     { /* Large max width */
         .format = "%.23s",
         .expected_output = "abcdefghijklmnopqrstuvw",
         .nargs = 1,
-        .args = {(uint)"abcdefghijklmnopqrstuvwxyz"},
+        .args = {(uintptr_t)"abcdefghijklmnopqrstuvwxyz"},
     },
     { /* Zero */
         .format = "%d",
@@ -517,7 +517,7 @@ static const struct {
         .format = "literal %08d\t%-8s\t%c%cliteral",
         .expected_output = "literal 00004000\tfoobar  \t\xfeXliteral",
         .nargs = 4,
-        .args = {4000, (uint)"foobar", 0xfe, 'X'},
+        .args = {4000, (uintptr_t)"foobar", 0xfe, 'X'},
     },
 };
 
@@ -532,7 +532,7 @@ static bool do_detailed_fprintf_tests(bool verbose, bool passed)
         const char *format = fprintf_specs[i].format;
         const char *expected_output = fprintf_specs[i].expected_output;
         uint nargs = fprintf_specs[i].nargs;
-        const uint *args = fprintf_specs[i].args;
+        const uintptr_t *args = fprintf_specs[i].args;
         int ret;
         int len = strlen(expected_output);
         uchar obuf[len + 1];

--- a/test/test_memory.c
+++ b/test/test_memory.c
@@ -20,7 +20,7 @@ thread test_memory(bool verbose)
     /* Allocate a small piece of memory */
     testPrint(verbose, "Allocate small piece");
     testblock = (struct memblock *)memget(1);
-    if (SYSERR == (uint)testblock)
+    if (SYSERR == (intptr_t)testblock)
     {
         passed = FALSE;
         testFail(verbose, "memget SYSERR");
@@ -68,7 +68,7 @@ thread test_memory(bool verbose)
     }
 
     saddr = stkget(1);
-    if (SYSERR == (uint)saddr)
+    if (SYSERR == (intptr_t)saddr)
     {
         passed = FALSE;
         testFail(verbose, "\nstkget SYSERR");


### PR DESCRIPTION
Please add port to the RISC-V 64 architecture. Currently it 
supports running on the emulated 'virt' machine.

It works with RISC-V project's GNU compiler toolchain 
https://github.com/riscv/riscv-gnu-toolchain
on riscv qemu  https://github.com/riscv/riscv-qemu.

Currently only serial device and basic functionality supported, 
All the relevant the tests in the testsuite pass..
