### PR TITLE
replace pngmath with imgmath in docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,7 +25,7 @@ sys.path.insert(0, os.path.abspath('.'))
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.pngmath', 'sphinx.ext.mathjax', 'xinusource']
+extensions = ['sphinx.ext.imgmath', 'sphinx.ext.mathjax', 'xinusource']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
## `sphinx.ext.pngmath` has already removed

According to the sphinx-doc, `pngmath` module has removed since v1.8.
https://github.com/sphinx-doc/sphinx/issues/6182

This PR includes the replacement of `pngmath` with `imgmath`, however but this ignores the backward compatibility.

